### PR TITLE
Include image template with docs

### DIFF
--- a/app/views/general/image.phtml
+++ b/app/views/general/image.phtml
@@ -1,0 +1,16 @@
+<?php
+$srcLight = $this->getParam('srcLight', '');
+$srcDark = $this->getParam('srcDark', $srcLight);
+$alt = $this->getParam('alt', 'Screenshot');
+$description = $this->getParam('description', '');
+?>
+<figure>
+    <picture>
+        <img class="force-light" alt="<?php echo $this->escape($alt); ?>" src="<?php echo $this->escape($srcLight); ?>?v=<?php echo APP_CACHE_BUSTER; ?>" loading="lazy">
+        <img class="force-dark" alt="<?php echo $this->escape($alt); ?>" src="<?php echo $this->escape($srcDark); ?>?v=<?php echo APP_CACHE_BUSTER; ?>" loading="lazy">
+    </picture>
+    
+    <?php if(!empty($description)): ?>
+        <figcaption class="text-fade"><?php echo $this->escape($description); ?></figcaption>
+    <?php endif; ?>
+</figure>


### PR DESCRIPTION
Pages like `/docs/functions` that use the general image template break when the template cannot be found:
https://github.com/appwrite/docs/blob/2844dff92b3e70572658faef4a0e53df43752a8e/app/views/docs/functions.phtml#L122-L130
This PR includes the image template in the same hierarchical place as before to both match expected values and the [README](https://github.com/appwrite/docs/blob/main/README.md#images).