### PR TITLE
Feat copy function env names

### DIFF
--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -211,7 +211,7 @@ void main() { // Init SDK
         <?php foreach($environments as $key => $environment): ?>
         <tr>
             <td><img src="" data-ls-attrs="src=/images/environments/<?php echo $this->escape($environment['logo'] ?? ''); ?>" alt="Function Env." class="avatar xxs" /></td>
-            <td><?php echo $this->escape($environment['name'] ?? ''); ?> <?php echo $this->escape($environment['version'] ?? ''); ?></td>
+            <td><span data-general-copy><?php echo $key ?> </span></td>
             <td><a href="https://hub.docker.com/r/appwrite/env-<?php echo $this->escape($key); ?>" target="_blank" rel="noopener"><?php echo $this->escape($environment['image'] ?? ''); ?> <i class="icon-link-ext"></i></a></td>
             <td><?php echo $this->escape(implode(' / ', $environment['supports'] ?? [])); ?></td>
         </tr>

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -211,7 +211,7 @@ void main() { // Init SDK
         <?php foreach($environments as $key => $environment): ?>
         <tr>
             <td><img src="" data-ls-attrs="src=/images/environments/<?php echo $this->escape($environment['logo'] ?? ''); ?>" alt="Function Env." class="avatar xxs" /></td>
-            <td><span data-general-copy><?php echo $key ?> </span></td>
+            <td><span data-general-copy><?php echo $this->escape($key); ?> </span></td>
             <td><a href="https://hub.docker.com/r/appwrite/env-<?php echo $this->escape($key); ?>" target="_blank" rel="noopener"><?php echo $this->escape($environment['image'] ?? ''); ?> <i class="icon-link-ext"></i></a></td>
             <td><?php echo $this->escape(implode(' / ', $environment['supports'] ?? [])); ?></td>
         </tr>


### PR DESCRIPTION
This PR changes the function names to be in the correct format to copy/paste directly. Currently, the list of function environments doesn't include the string `$key` used e.g. to create a cloud function from the CLI.

This PR should remain in draft until the website has been updated with the new copy/paste component.

Preview:
![copytoclipboard](https://user-images.githubusercontent.com/9708641/111527056-d6b2f180-8735-11eb-8d02-4edc7c9fe2a3.png)
