### PR TITLE
Fix slight typo on /docs/admin

### DIFF
--- a/app/views/docs/admin.phtml
+++ b/app/views/docs/admin.phtml
@@ -1,4 +1,4 @@
-<p>The Appwrite API has two different modes he can work with, the first mode is the client mode, which is the <b>default</b> mode, and the second one is the <b>admin</b> or server mode.</p>
+<p>The Appwrite API has two different modes it can use, the first mode is the client mode, which is the <b>default</b> mode, and the second one is the <b>admin</b> or server mode.</p>
 
 <p>When using Appwrite from the client-side, you should go with the normal default mode. This mode allows every user of your project to access only resources he has granted access to. When running in admin mode, you remove Appwrite default access restriction and ultimately allow access to any of the resources available on your Appwrite project (files, documents, or collections).</p>
 


### PR DESCRIPTION
Using `he` here makes the API seem like a person, I've corrected it so it doesn't make the api look like a person