### PR TITLE
Fix for missing link and typo

### DIFF
--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -129,7 +129,7 @@ $image = new View(__DIR__.'/../general/image.phtml');
         ->render();
 ?>
 
-<p>To execute a function from the Appwrite console, click the 'Execute Now' button on your function's overview page. To execute a function from the API, send a POST request to the <a href="" target="_blank">function execution endpoint</a>.</p>
+<p>To execute a function from the Appwrite console, click the 'Execute Now' button on your function's overview page. To execute a function from the API, send a POST request to the <a href="/docs/client/functions#functionsCreateExecution" target="_blank">function execution endpoint</a>.</p>
 
 <p>The function execution endpoint is available from both Appwrite client and server APIs. To execute your function from the <b>server API</b>, you need an API key with 'execution.write' scope.</p>
 
@@ -333,7 +333,7 @@ void main() { // Init SDK
 
 <h2>Monitor & Debug</h2>
 
-<p>You can monitor your function execution usgae stats and logs from both your Appwrite console and the <a href="" traget="_blank">Appwrite server API</a>. To access your functions usage stats and logs from your console, click the 'Usage' tab in your function dashboard.</p>
+<p>You can monitor your function execution usage stats and logs from your Appwrite console. To access your functions usage stats and logs, click the 'Usage' tab in your function dashboard.</p>
 
 <p>The usage screen in your console will allow you to track the number of execution and your function CPU usage time. You can also review a detailed log of your function execution history, including the function exit code, output log, and error log.</p>
 


### PR DESCRIPTION
Fixed a missing link and a typo in the functions tutorial.