### PR TITLE
Fix missing OVH Link in Custom Domains Docs

### DIFF
--- a/app/views/docs/custom-domains.phtml
+++ b/app/views/docs/custom-domains.phtml
@@ -237,7 +237,7 @@ $dns = [
     ],
     [
         'name' => 'OVH',
-        'url' => '',
+        'url' => 'https://ovh.com',
         'docs' => [
             'a' => null,
             'cname' => null,


### PR DESCRIPTION
Fix missing OVH Link in Custom Domains Docs