### PR TITLE
📝 Add browser caching after upgrade notice

### DIFF
--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -36,3 +36,11 @@ docker-compose exec appwrite migrate</code></pre>
 </div>
 
 <p>Once the migration process has completed successfully, you're all set to use the latest version of Appwrite!</p>
+
+<div class="notice margin-bottom">
+    <h3>A Note About Browser Caching</h3>
+
+    <p>After upgrading, you may notice no change in the dashboard including version not changed and/or no new feature.</p>
+
+    <p>To ensure seeing correct version of the dashboard, <a href="https://www.howtogeek.com/672607/how-to-hard-refresh-your-web-browser-to-bypass-your-cache/" target="_blank" rel="noopener">try to clear your browser cache</a></p>
+</div>


### PR DESCRIPTION
While tried to upgrade from 0.8.0 to 0.9.0, I noticed no change in the dashboard...

After trying to reinstall about 3 times, I tried to refresh my browser (Brave) and the new dashboard version was visible 😀

I added a notice in the doc to prevent some headaches for some people 😁