### PR TITLE
🐝 Fixed spelling mistakes

### DIFF
--- a/app/views/docs/error-codes.phtml
+++ b/app/views/docs/error-codes.phtml
@@ -46,7 +46,7 @@
         <tr>
             <td data-title="Code: ">404</td>
             <td data-title="Text: ">Not Found</td>
-            <td data-title="Description: ">The URI requested is invalid or the resource requested, such as a user, does not exists.</td>
+            <td data-title="Description: ">The URI requested is invalid or the resource requested, such as a user, does not exist.</td>
         </tr>
 
         <tr>

--- a/app/views/docs/permissions.phtml
+++ b/app/views/docs/permissions.phtml
@@ -2,7 +2,7 @@
 
 <p>Using permissions, you can decide that only <span class="tag">user A</span> and <span class="tag">user B</span> will have read access to a specific database document, while <span class="tag">user C</span> and <span class="tag">team X</span> will be the only ones with write access.</p>
 
-<p>As the name suggests, read permission will give allow users and teams to have access to view a resource while with write permission, they will be able to both update or delete it.</p>
+<p>As the name suggests, read permission will allow users and teams to view a resource while with write permission, they will be able to both update or delete it.</p>
 
 <p>Read and write permissions can be given to specific users, entire teams, or only to a particular group of role members inside a team.</p>
 
@@ -23,7 +23,7 @@
 <div class="notice calm margin-top-large margin-bottom-large">
     <h4>Note</h4>
     
-    <p>You will need an active session to handle database transactions for your collections</p>
+    <p>You will need an active session to handle database transactions for your collections.</p>
     <p>If you have rules where you allow for wild cards or role:guest in a collection, you can create an Anonymous Session before you make the API call.</p>
 </div>
 


### PR DESCRIPTION
As a part of the onboarding process, I dove deeper into the docs and while reading them, found these tiny mistakes.

---

Other than that, I also found that linebreaks are not working properly with descriptions from Appwrite:
![CleanShot 2021-08-24 at 10 10 24](https://user-images.githubusercontent.com/19310830/130585701-b8902227-9fd3-4454-ab9a-f88ac82b528c.png)

Also, `these blocks` does not display properly, even tho the design for it is already prepared:
![CleanShot 2021-08-24 at 10 09 42](https://user-images.githubusercontent.com/19310830/130585847-c0eed89e-98c1-4557-8b99-fd98904dde12.png)
![CleanShot 2021-08-24 at 10 08 48](https://user-images.githubusercontent.com/19310830/130585856-7a082f05-2e88-40f2-948a-8d2cb29c4f6f.png)

I was not able to fix these two because I could not set up a local server.
