### PR TITLE
Update getting-started-for-flutter.phtml

### DIFF
--- a/app/views/docs/getting-started-for-flutter.phtml
+++ b/app/views/docs/getting-started-for-flutter.phtml
@@ -13,7 +13,7 @@ foreach($platforms['client']['languages'] as $lang) {
 
 $version = (isset($versions['flutter'])) ? $versions['flutter'] : '';
 ?>
-<p>Appwrite is a development platform providing you easy yet powerful API and management console to get your next project up and running quickly.</p>
+<p>Appwrite is a development platform providing you an easy yet powerful API and management console to get your next project up and running quickly.</p>
 
 <p>This tutorial will help you start using Appwrite products and build your next project. Before starting, make sure you have followed the Appwrite <a href="/docs/installation">installation guide</a>, and you have an Appwrite server instance up and running on your host machine or server.</p>
 


### PR DESCRIPTION
A small grammatical mistake was found in [getting started for flutter ](https://appwrite.io/docs/getting-started-for-flutter) docs. This PR fixes that issue