### PR TITLE
Fix installation Docker

### DIFF
--- a/app/views/docs/installation.phtml
+++ b/app/views/docs/installation.phtml
@@ -25,7 +25,7 @@
 
 <h3><a href="/docs/installation#windows" id="windows">Windows</a></h3>
 
-<p>Hyper-V and Containers Windows features must be enabled to run Appwrite on Windows with Docker. If you don't have these features available, you can install <a href="https://docs.docker.com/toolbox/toolbox_install_windows/" target="_blank" rel="noopener">Docker Toolbox</a> that uses Virtualbox to run Appwrite on a Virtual Machine.</p>
+<p>Hyper-V and Containers Windows features must be enabled to run Appwrite on Windows with Docker. If you don't have these features available, you can install <a href="https://docs.docker.com/desktop/windows/install/" target="_blank" rel="noopener">Docker Desktop</a> that uses Virtualbox to run Appwrite on a Virtual Machine.</p>
 
 <ul class="phases clear" data-ui-phases>
     <li>


### PR DESCRIPTION
Docker Toolbox has been deprecated and is no longer in active development, [see](https://docs.docker.com/toolbox/toolbox_install_windows/).