### PR TITLE
Fix: add missing closing tags around code block

### DIFF
--- a/app/views/docs/getting-started-for-android.phtml
+++ b/app/views/docs/getting-started-for-android.phtml
@@ -61,7 +61,7 @@ $androidVersion = (isset($versions['android'])) ? $versions['android'] : '';
       </intent-filter>
     </activity>
   </application>
-</manifest>'); ?>
+</manifest>'); ?></code></pre>
 </div>
 
 <h2><a href="/docs/getting-started-for-android#initSDK" id="initSDK">Init your SDK</a></h2>


### PR DESCRIPTION
Tags were missing around a code block in the `Getting Started For Android` docs, causing the docs page to break:

Before Fix
![unknown](https://user-images.githubusercontent.com/9708641/138512786-0a45accf-ef5d-4c00-a3b3-c9f767fb543c.png)


After Fix
![addedmissingtags](https://user-images.githubusercontent.com/9708641/138512800-f9ac8b58-b8a6-4620-a359-d8c3399818c7.png)
</details>