### PR TITLE
Fixed the install for Ruby command

### DIFF
--- a/app/views/docs/getting-started-for-server.phtml
+++ b/app/views/docs/getting-started-for-server.phtml
@@ -46,7 +46,7 @@ $kotlinVersion = $versions['kotlin'] ?? '';
     <li>
         <h3>Ruby</h3>
         <div class="ide margin-top-small" data-lang="bash" data-lang-label="Bash">
-            <pre class="line-numbers"><code class="prism language-bash" data-prism>gem install appwrite --save</code></pre>
+            <pre class="line-numbers"><code class="prism language-bash" data-prism>gem install appwrite</code></pre>
         </div>
     </li>
     <li>


### PR DESCRIPTION
The getting started for server documentation had the instructions for Ruby to run `gem install appwrite --save`. However, since `--save` was not valid for Ruby, I removed it.

I also made sure that running `gem install appwrite` on my computer installed appwrite correctly.

Fixes #82 