### PR TITLE
Fix: improper page attributes and parameters

### DIFF
--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -219,7 +219,7 @@ void main() { // Init SDK
     </tbody>
 </table>
 
-<h2><a href="/docs/functions#enviromentVariables" id="enviromentVariables">Environment Variables</a></h2>
+<h2><a href="/docs/functions#environmentVariables" id="environmentVariables">Environment Variables</a></h2>
 
 <p>Environment variables supplied by Appwrite in addition to your own defined environment variables that you can access from your function code. These variables give you information about your execution runtime environment.</p>
 
@@ -387,7 +387,7 @@ $image = new View(__DIR__.'/../general/image.phtml');
     </li>
 </ul>
 
-<p>The example above shows how you can mount your current working dir into the "appwrite/env-node-15.5:1.0.0" Cloud Functions runtime and execute a custom command to simulate exactly how the Appwirte server will execute the function on the Appwrite server. You can also pass multiple environment variables that your code might require.</p>
+<p>The example above shows how you can mount your current working dir into the "appwrite/env-node-15.5:1.0.0" Cloud Functions runtime and execute a custom command to simulate exactly how the Appwrite server will execute the function on the Appwrite server. You can also pass multiple environment variables that your code might require.</p>
 
 <p>When running a Cloud Functions runtime for a coding language that uses a central directory for managing all dependencies, you will need to package all your dependencies in your working directory under the ".appwrite" folder as mentioned in the "Handling Dependencies" step above. This will ensure your function container can access all required packages and execute your function successfully.</p>
 

--- a/app/views/docs/index.phtml
+++ b/app/views/docs/index.phtml
@@ -13,7 +13,7 @@ $cols = [
     'xxxl' => ['nav' => 'span-2', 'main' => 'span-10'],
 ]
 ?>
-<div class="zone <?php echo $layout; ?> docs" data-general-strech-value="<?php echo $layout; ?>">
+<div class="zone <?php echo $layout; ?> docs" data-general-stretch-value="<?php echo $layout; ?>">
     <div class="row responsive text-size-small">
         <div class="col <?php echo $cols[$layout]['nav']; ?>">
             <nav data-ui-highlight data-ls-ui-open>

--- a/app/views/docs/index.phtml
+++ b/app/views/docs/index.phtml
@@ -13,7 +13,7 @@ $cols = [
     'xxxl' => ['nav' => 'span-2', 'main' => 'span-10'],
 ]
 ?>
-<div class="zone <?php echo $layout; ?> docs" data-general-stretch-value="<?php echo $layout; ?>">
+<div class="zone <?php echo $layout; ?> docs" data-general-strech-value="<?php echo $layout; ?>">
     <div class="row responsive text-size-small">
         <div class="col <?php echo $cols[$layout]['nav']; ?>">
             <nav data-ui-highlight data-ls-ui-open>

--- a/app/views/docs/rules.phtml
+++ b/app/views/docs/rules.phtml
@@ -5,7 +5,7 @@ $markdown->setSafeMode(true);
 
 <p>Rules are the building blocks of Appwrite Database collections. Using rules and their validators you are able to structure your project data and make sure you only get the data in the formats you expect to.</p>
 
-<h2><a href="/docs/rules#ruleOjbect" id="ruleObject">Rule Object</a></h2>
+<h2><a href="/docs/rules#ruleObject" id="ruleObject">Rule Object</a></h2>
 
 <?php
     $parameters = [

--- a/app/views/docs/service.phtml
+++ b/app/views/docs/service.phtml
@@ -15,7 +15,7 @@ $platforms      = $this->getParam('platforms', []);
 $version        = $this->getParam('version', '');
 $versionDocs    = $this->getParam('versionDocs', '');
 $versions       = $this->getParam('versions', []);
-$classess       = [];
+$classes        = [];
 $paths          = $spec['paths'] ?? [];
 $codes          = [
     '200' => [
@@ -80,7 +80,7 @@ $paramSDK = (!empty($sdk)) ? '?sdk='.$sdk : '';
     <style>
         <?php foreach ($platforms as $key => $platform):
             if(!in_array($key, $blacklist) && $platform['enabled']) {
-                $classess[] = 'example-for-'.$key;
+                $classes[] = 'example-for-'.$key;
             }
             ?>
 
@@ -192,7 +192,7 @@ $paramSDK = (!empty($sdk)) ? '?sdk='.$sdk : '';
     </div>
 
     <?php if(!empty($path) && file_exists($path)): ?>
-        <div class="row responsive <?php echo implode(' ', $classess); ?>">
+        <div class="row responsive <?php echo implode(' ', $classes); ?>">
             <div class="col span-8 margin-bottom">
                 
                 <div class="content margin-end-xl">


### PR DESCRIPTION
Fixed inconsistent heading reference attributes for Functions and Rules documentation pages and misspelled PHP attributes in Index and Service page scripts. Also fixed typo on word "Appwrite" in Functions documentation page.