### PR TITLE
Fix: update Client instantiations and resolve typos

### DIFF
--- a/app/views/docs/getting-started-for-android.phtml
+++ b/app/views/docs/getting-started-for-android.phtml
@@ -44,7 +44,7 @@ $androidVersion = (isset($versions['android'])) ? $versions['android'] : '';
 
 <h3><a href="/docs/getting-started-for-android#OAuthCallback" id="OAuthCallback">OAuth Callback</a></h3>
 
-<p>In order to capture the Appwrite OAuth callback url, the following activity needs to be added inside the `&lt;application&gt;` tag, along side the existing `&lt;activity&gt;` tags in your <a href="https://github.com/appwrite/playground-for-android/blob/master/app/src/main/AndroidManifest.xml" target="_blank" rel="noopener">AndroidManifest.xml</a>. Be sure to relpace the <b>[PROJECT_ID]</b> string with your actual Appwrite project ID. You can find your Appwrite project ID in you project settings screen in your Appwrite console.</p>
+<p>In order to capture the Appwrite OAuth callback url, the following activity needs to be added inside the `&lt;application&gt;` tag, along side the existing `&lt;activity&gt;` tags in your <a href="https://github.com/appwrite/playground-for-android/blob/master/app/src/main/AndroidManifest.xml" target="_blank" rel="noopener">AndroidManifest.xml</a>. Be sure to replace the <b>[PROJECT_ID]</b> string with your actual Appwrite project ID. You can find your Appwrite project ID in you project settings screen in your Appwrite console.</p>
 
 <div class="ide" data-lang="html" data-lang-label="XML">
     <pre class="line-numbers"><code class="prism language-xml" data-prism><?php echo $this->escape('<manifest ...>
@@ -76,7 +76,7 @@ import io.appwrite.services.Account
 val client = Client(context)
   .setEndpoint("https://[HOSTNAME_OR_IP]/v1") // Your API Endpoint
   .setProject("5df5acd0d48c2") // Your project ID
-  .setSelfSigned(true) // For self signed certificates, only use for development</code></pre>
+  .setSelfSigned(status: true) // For self signed certificates, only use for development</code></pre>
 </div>
 
 <p>Before starting to send any API calls to your new Appwrite instance, make sure your Android emulators has network access to the Appwrite server hostname or IP address.</p>
@@ -119,7 +119,7 @@ import io.appwrite.services.Account
 val client = Client(context)
   .setEndpoint("https://[HOSTNAME_OR_IP]/v1") // Your API Endpoint
   .setProject("5df5acd0d48c2") // Your project ID
-  .setSelfSigned(true) // For self signed certificates, only use for development
+  .setSelfSigned(status: true) // For self signed certificates, only use for development
 
 // Register User
 val account = Account(client)

--- a/app/views/docs/getting-started-for-flutter.phtml
+++ b/app/views/docs/getting-started-for-flutter.phtml
@@ -33,7 +33,7 @@ $version = (isset($versions['flutter'])) ? $versions['flutter'] : '';
 
 <p>For <b>Android</b> first add your app <u>name</u> and <u>package name</u>, Your package name is generally the <b>applicationId</b> in your app-level <a href="https://github.com/appwrite/playground-for-flutter/blob/0fdbdff98384fff940ed0b1e08cf14cfe3a2be3e/android/app/build.gradle#L41" target="_blank" rel="noopener">build.gradle</a> file. By registering your new app platform, you are allowing your app to communicate with the Appwrite API.</p>
 
-<p>In order to capture the Appwrite OAuth callback url, the following activity needs to be added inside the `&lt;application&gt;` tag, along side the existing `&lt;activity&gt;` tags in your <a href="https://github.com/appwrite/playground-for-flutter/blob/master/android/app/src/main/AndroidManifest.xml" target="_blank" rel="noopener">AndroidManifest.xml</a>. Be sure to relpace the <b>[PROJECT_ID]</b> string with your actual Appwrite project ID. You can find your Appwrite project ID in you project settings screen in your Appwrite console.</p>
+<p>In order to capture the Appwrite OAuth callback url, the following activity needs to be added inside the `&lt;application&gt;` tag, along side the existing `&lt;activity&gt;` tags in your <a href="https://github.com/appwrite/playground-for-flutter/blob/master/android/app/src/main/AndroidManifest.xml" target="_blank" rel="noopener">AndroidManifest.xml</a>. Be sure to replace the <b>[PROJECT_ID]</b> string with your actual Appwrite project ID. You can find your Appwrite project ID in you project settings screen in your Appwrite console.</p>
 
 <div class="ide" data-lang="html" data-lang-label="XML">
     <pre class="line-numbers"><code class="prism language-xml" data-prism><?php echo $this->escape('<manifest ...>
@@ -61,7 +61,7 @@ $version = (isset($versions['flutter'])) ? $versions['flutter'] : '';
 <p>The Appwrite SDK uses ASWebAuthenticationSession on iOS 12+ and SFAuthenticationSession on iOS 11 to allow OAuth authentication. You have to change your iOS Deployment Target in Xcode to be iOS >= 11 to be able to build your app on an emulator or a real device.</p>
 
 <ol class="margin-top margin-bottom-large">
-  <li class="margin-bottom-small">In Xcode, open Runner.xcworkspace in your app's ios folder.
+  <li class="margin-bottom-small">In Xcode, open Runner.xcworkspace in your app's iOS folder.
   <li class="margin-bottom-small">To view your app's settings, select the Runner project in the Xcode project navigator. Then, in the main view sidebar, select the Runner target.</li>
   <li class="margin-bottom-small">Select the General tab.</li>
   <li class="margin-bottom-small">In Deployment Info, 'Target' select iOS 11.0</li>
@@ -171,7 +171,7 @@ Client client = Client();
 client
     .setEndpoint('https://localhost/v1') // Your Appwrite Endpoint
     .setProject('5e8cf4f46b5e8') // Your project ID
-    .setSelfSigned(true) // For self signed certificates, only use for development
+    .setSelfSigned(status: true) // For self signed certificates, only use for development
 ;
 
 // Register User

--- a/app/views/docs/getting-started-for-server.phtml
+++ b/app/views/docs/getting-started-for-server.phtml
@@ -186,12 +186,14 @@ client
         <div class="ide margin-top-small" data-lang="dart" data-lang-label="Dart SDK">
             <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:dart_appwrite/dart_appwrite.dart';
 
-Client client = Client();
-client
-    .setEndpoint('https://[HOSTNAME_OR_IP]/v1') // Your API Endpoint
-    .setProject('5df5acd0d48c2') // Your project ID
-    .setKey('919c2d18fb5d4...a2ae413da83346ad2') // Your secret API key
-;</code></pre>
+void main() {
+  Client client = Client();
+  client
+      .setEndpoint('https://[HOSTNAME_OR_IP]/v1') // Your API Endpoint
+      .setProject('5df5acd0d48c2') // Your project ID
+      .setKey('919c2d18fb5d4...a2ae413da83346ad2') // Your secret API key
+  ;
+}</code></pre>
         </div>
     </li>
     <li>
@@ -358,12 +360,14 @@ client
         <div class="ide margin-top-small" data-lang="dart" data-lang-label="Dart SDK">
             <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:dart_appwrite/dart_appwrite.dart';
 
-Client client = Client();
-client
-    .setEndpoint('https://[HOSTNAME_OR_IP]/v1') // Your API Endpoint
-    .setProject('5df5acd0d48c2') // Your project ID
-    .setJWT('919c2d18fb5d4...a2ae413da83346ad2') // Your secret API key
-;</code></pre>
+void main() {
+  Client client = Client();
+  client
+      .setEndpoint('https://[HOSTNAME_OR_IP]/v1') // Your API Endpoint
+      .setProject('5df5acd0d48c2') // Your project ID
+      .setJWT('919c2d18fb5d4...a2ae413da83346ad2') // Your secret API key
+  ;
+}</code></pre>
         </div>
     </li>
     <li>
@@ -608,22 +612,24 @@ promise.then(function (response) {
         <div class="ide margin-top-small" data-lang="dart" data-lang-label="Dart SDK">
             <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:dart_appwrite/dart_appwrite.dart';
 
-final client = Client();
-final users = Users(client);
+void main() {
+  final client = Client();
+  final users = Users(client);
 
-client
-    .setEndpoint('https://[HOSTNAME_OR_IP]/v1') // Your API Endpoint
-    .setProject('5df5acd0d48c2') // Your project ID
-    .setKey('919c2d18fb5d4...a2ae413da83346ad2') // Your secret API key
-;
+  client
+      .setEndpoint('https://[HOSTNAME_OR_IP]/v1') // Your API Endpoint
+      .setProject('5df5acd0d48c2') // Your project ID
+      .setKey('919c2d18fb5d4...a2ae413da83346ad2') // Your secret API key
+  ;
 
-final res = users.create('email@example.com', 'password');
+  final res = users.create('email@example.com', 'password');
 
-res.then((response) {
-    print(response);
-}).catchError((error) {
-    print(error);
-});</code></pre>
+  res.then((response) {
+      print(response);
+  }).catchError((error) {
+      print(error);
+  });
+}</code></pre>
         </div>
     </li>
     <li>

--- a/app/views/docs/realtime.phtml
+++ b/app/views/docs/realtime.phtml
@@ -47,7 +47,7 @@ sdk.subscribe(channel, callback);</code></pre>
 client
     .setEndpoint('https://localhost/v1') // Your Appwrite Endpoint
     .setProject('5e8cf4f46b5e8') // Your project ID
-    .setSelfSigned(true) // For self signed certificates, only use for development
+    .setSelfSigned(status: true) // For self signed certificates, only use for development
 ;
 
 final realtime = Realtime(client);
@@ -65,7 +65,7 @@ subscription.stream.listen(callback);
 client
     .setEndpoint("https://[HOSTNAME_OR_IP]/v1") // Your API Endpoint
     .setProject("5df5acd0d48c2") // Your project ID
-    .setSelfSigned(true) // For self signed certificates, only use for development
+    .setSelfSigned(status: true) // For self signed certificates, only use for development
 
 val realtime = Realtime(client)
 
@@ -291,7 +291,7 @@ subscription.close()</code></pre>
     </tbody>
 </table>
 
-<p>If you subscribe to the <span class="tag">documents</span> channel and a document the user is allowed to read is updated, you will receive an object containing informations about the event and the updated document.</p>
+<p>If you subscribe to the <span class="tag">documents</span> channel and a document the user is allowed to read is updated, you will receive an object containing information about the event and the updated document.</p>
 
 <p>The response will look like this:</p>
 

--- a/app/views/docs/security.phtml
+++ b/app/views/docs/security.phtml
@@ -4,7 +4,7 @@
 
 <h2>SSL Certificates</h2>
 
-<p>Appwrite uses <a href="https://github.com/traefik/traefik" target="_blank" rel="noopener">Traefik</a> and <a href="https://letsencrypt.org/" target="_blank" rel="noopener">Let'sencrypt</a> to serve, create, and renew SSL certificates for your Appwrite server and any custom domains set for your projects.</p>
+<p>Appwrite uses <a href="https://github.com/traefik/traefik" target="_blank" rel="noopener">Traefik</a> and <a href="https://letsencrypt.org/" target="_blank" rel="noopener">Let's Encrypt</a> to serve, create, and renew SSL certificates for your Appwrite server and any custom domains set for your projects.</p>
 
 <p>Once a new SSL certificate has been created, Appwrite will renew it 60 days before its 90 days of default expiration. Auto-generation of SSL certificates is only possible for public-facing domains. When used with localhost, Appwrite will generate a <a href="https://en.wikipedia.org/wiki/Self-signed_certificate" target="_blank" rel="noopener">self-signed SSL certificate</a>.</p>
 
@@ -16,7 +16,7 @@
 
 <h2>Password Hashing</h2>
 
-<h2>Resource-level Secuirty</h2>
+<h2>Resource-level Security</h2>
 
 <h2>Abuse Protection & Rate-Limiting</h2>
 


### PR DESCRIPTION
Closes #84 (completes what was requested by @eldadfux [here](https://github.com/appwrite/docs/pull/85#issuecomment-950196482))

Added missing "status" parameter on Client.setSelfSigned method examples in Getting Started for Android and Getting Started for Flutter pages as well as Realtime documentation page. Also fixes typos in Realtime and Security pages and updated Getting Started docs code to wrap functional code inside "void main" so it works directly when copied.