### PR TITLE
Fix self-signed cert param

### DIFF
--- a/app/views/docs/getting-started-for-android.phtml
+++ b/app/views/docs/getting-started-for-android.phtml
@@ -76,7 +76,7 @@ import io.appwrite.services.Account
 val client = Client(context)
   .setEndpoint("https://[HOSTNAME_OR_IP]/v1") // Your API Endpoint
   .setProject("5df5acd0d48c2") // Your project ID
-  .setSelfSigned(true) // For self signed certificates, only use for development</code></pre>
+  .setSelfSigned(status: true) // For self signed certificates, only use for development</code></pre>
 </div>
 
 <p>Before starting to send any API calls to your new Appwrite instance, make sure your Android emulators has network access to the Appwrite server hostname or IP address.</p>
@@ -119,7 +119,7 @@ import io.appwrite.services.Account
 val client = Client(context)
   .setEndpoint("https://[HOSTNAME_OR_IP]/v1") // Your API Endpoint
   .setProject("5df5acd0d48c2") // Your project ID
-  .setSelfSigned(true) // For self signed certificates, only use for development
+  .setSelfSigned(status: true) // For self signed certificates, only use for development
 
 // Register User
 val account = Account(client)

--- a/app/views/docs/getting-started-for-apple.phtml
+++ b/app/views/docs/getting-started-for-apple.phtml
@@ -107,7 +107,7 @@ $appleVersion = (isset($versions['swift-client'])) ? $versions['swift-client'] :
 let client = Client()
   .setEndpoint("https://[HOSTNAME_OR_IP]/v1") // Your API Endpoint
   .setProject("5df5acd0d48c2") // Your project ID
-  .setSelfSigned() // For self signed certificates, only use for development</code></pre>
+  .setSelfSigned(status: true) // For self signed certificates, only use for development</code></pre>
 </div>
 
 <p>If you're using a physical device instead of a simulator, ensure that you can access your Appwrite instance before sending API calls.</p>
@@ -155,7 +155,7 @@ import Appwrite
 let client = Client()
   .setEndpoint("https://[HOSTNAME_OR_IP]/v1") // Your API Endpoint
   .setProject("5df5acd0d48c2") // Your project ID
-  .setSelfSigned() // For self signed certificates, only use for development
+  .setSelfSigned(status: true) // For self signed certificates, only use for development
 
 // Register User
 let account = Account(client: client)

--- a/app/views/docs/getting-started-for-flutter.phtml
+++ b/app/views/docs/getting-started-for-flutter.phtml
@@ -171,7 +171,7 @@ Client client = Client();
 client
     .setEndpoint('https://localhost/v1') // Your Appwrite Endpoint
     .setProject('5e8cf4f46b5e8') // Your project ID
-    .setSelfSigned(true) // For self signed certificates, only use for development
+    .setSelfSigned(status: true) // For self signed certificates, only use for development
 ;
 
 // Register User

--- a/app/views/docs/realtime.phtml
+++ b/app/views/docs/realtime.phtml
@@ -47,7 +47,7 @@ sdk.subscribe(channel, callback);</code></pre>
 client
     .setEndpoint('https://localhost/v1') // Your Appwrite Endpoint
     .setProject('5e8cf4f46b5e8') // Your project ID
-    .setSelfSigned(true) // For self signed certificates, only use for development
+    .setSelfSigned(status: true) // For self signed certificates, only use for development
 ;
 
 final realtime = Realtime(client);
@@ -65,7 +65,7 @@ subscription.stream.listen(callback);
 client
     .setEndpoint("https://[HOSTNAME_OR_IP]/v1") // Your API Endpoint
     .setProject("5df5acd0d48c2") // Your project ID
-    .setSelfSigned(true) // For self signed certificates, only use for development
+    .setSelfSigned(status: true) // For self signed certificates, only use for development
 
 val realtime = Realtime(client)
 


### PR DESCRIPTION
Closes #84 

It seems like Issue #84 has gone stale and the corresponding PR #85 hasn't been updated by the original submitter in 19 days. 

[Eldad stated here](https://github.com/appwrite/docs/pull/85#issuecomment-950196482) to apply the `.setSelfSigned(status: true)` parameter wherever it appears in the Getting Started guides, which this PR now does. 👍 

If PR #85 becomes active again, then please close this PR!