### PR TITLE
Fix: OR queries require an array of values

### DIFF
--- a/app/views/docs/database.phtml
+++ b/app/views/docs/database.phtml
@@ -338,7 +338,7 @@ func main() {
         <h3>Web</h3>
         <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
             <pre class="line-numbers"><code class="prism language-javascript" data-prism>sdk.database.listDocuments('movies', [
-            Query.equal('title', 'Avatar', 'Lord of the Rings'),
+            Query.equal('title', ['Avatar', 'Lord of the Rings']),
             Query.greater('year', 1999)
         ]);
         </code></pre>


### PR DESCRIPTION
Fixes documentation for database queries with Web SDK - the value can be a primitive or array of values, not variadic. 