### PR TITLE
feat: add one-click setups to installation page

### DIFF
--- a/app/views/docs/installation.phtml
+++ b/app/views/docs/installation.phtml
@@ -53,6 +53,51 @@
     </li>
 </ul>
 
+<h2><a href="/docs/getting-started-for-web#one-click-setups" id="one-click-setups">One-Click Setups</a></h2>
+
+<p>
+    In addition to running Appwrite locally, you can also launch Appwrite using a pre-configured setup.
+    This allows you to get up and running with Appwrite quickly without installing Docker on your local machine.
+</p>
+
+<p>Choose from one of the providers below:</p>
+
+<table cellspacing="0" cellpadding="0" border="0" class="full margin-bottom-large text-size-small vertical">
+    <thead>
+        <tr>
+            <th style="width: 80px"></th>
+            <th style="width: 180px">Provider</th>
+            <th style="width: 120px"></th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <img src="/images-ee/one-click/gitpod.svg" alt="Logo" height="30" class="force-light sdk-logo margin-start margin-end" />
+                <img src="/images-ee/one-click/dark/gitpod.svg" alt="Logo" height="30" class="force-dark sdk-logo margin-start margin-end" />
+            </td>
+            <td>
+                Gitpod
+            </td>
+            <td>
+                <a href="https://gitpod.io/#https://github.com/appwrite/integration-for-gitpod" target="_blank" rel="noopener">Install</a>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <img src="/images-ee/one-click/digital-ocean.svg" alt="Logo" height="30" class="force-light sdk-logo margin-start margin-end" />
+                <img src="/images-ee/one-click/dark/digital-ocean.svg" alt="Logo" height="30" class="force-dark sdk-logo margin-start margin-end" />
+            </td>
+            <td>
+                Digital Ocean
+            </td>
+            <td>
+                <a href="https://marketplace.digitalocean.com/apps/appwrite" target="_blank" rel="noopener">Install</a>
+            </td>
+        </tr>        
+    </tbody>
+</table>
+
 <h3><a href="/docs/installation#manual" id="manual">Manual (using docker-compose.yml)</a></h3>
 
 <p>For advanced Docker users, the manual installation might seem more familiar. To setup Appwrite manually, download the Appwrite base <a href="https://gist.github.com/eldadfux/977869ff6bdd7312adfd4e629ee15cc5" target="_blank">docker-compose.yml and .env</a> files. After the download completes, update the different environment variables as you wish in the .env file and start the Appwrite stack using the following Docker command:</p>

--- a/app/views/docs/installation.phtml
+++ b/app/views/docs/installation.phtml
@@ -73,6 +73,18 @@
     <tbody>
         <tr>
             <td>
+                <img src="/images-ee/one-click/digital-ocean.svg" alt="Logo" height="30" class="force-light sdk-logo margin-start margin-end" />
+                <img src="/images-ee/one-click/dark/digital-ocean.svg" alt="Logo" height="30" class="force-dark sdk-logo margin-start margin-end" />
+            </td>
+            <td>
+                DigitalOcean
+            </td>
+            <td>
+                <a href="https://marketplace.digitalocean.com/apps/appwrite" target="_blank" rel="noopener">Install</a>
+            </td>
+        </tr>        
+        <tr>
+            <td>
                 <img src="/images-ee/one-click/gitpod.svg" alt="Logo" height="30" class="force-light sdk-logo margin-start margin-end" />
                 <img src="/images-ee/one-click/dark/gitpod.svg" alt="Logo" height="30" class="force-dark sdk-logo margin-start margin-end" />
             </td>
@@ -83,18 +95,6 @@
                 <a href="https://gitpod.io/#https://github.com/appwrite/integration-for-gitpod" target="_blank" rel="noopener">Install</a>
             </td>
         </tr>
-        <tr>
-            <td>
-                <img src="/images-ee/one-click/digital-ocean.svg" alt="Logo" height="30" class="force-light sdk-logo margin-start margin-end" />
-                <img src="/images-ee/one-click/dark/digital-ocean.svg" alt="Logo" height="30" class="force-dark sdk-logo margin-start margin-end" />
-            </td>
-            <td>
-                Digital Ocean
-            </td>
-            <td>
-                <a href="https://marketplace.digitalocean.com/apps/appwrite" target="_blank" rel="noopener">Install</a>
-            </td>
-        </tr>        
     </tbody>
 </table>
 


### PR DESCRIPTION
- Adds a section to the installation page for using Appwrite through providers without installing Docker locally.

Dark Mode:

![image](https://user-images.githubusercontent.com/42211/157513263-57c7ada5-5a98-4b17-9b7c-c6bc72a161ae.png)

Light Mode:

![image](https://user-images.githubusercontent.com/42211/157513350-22163e9d-bbdc-4420-b7bd-57b92e953acd.png)
