### PR TITLE
Tentative changes to clarify migration location

### DIFF
--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -12,7 +12,17 @@
 
 <!-- <p>The data migration tool will allow you to easily migrate your current Appwrite data to work with the new version. </p> -->
 
-<p> The first step is to install the latest version of Appwrite. Head to the directory where you first installed Appwrite. This is the parent directory, where you will find the <b>appwrite</b> directory that contains the <b>docker-compose.yml</b> and <b>.env</b> files.</p>
+<p> The first step is to install the latest version of Appwrite. Head to the directory where you ran your previous Appwrite install command. 
+
+<div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>
+    parent_directory  <= you run the command in this directory
+    └── appwrite
+        └── docker-compose.yml
+    </code></pre>
+</div>
+
+This is the parent directory, where you will find the <b>appwrite</b> directory that contains the <b>docker-compose.yml</b> and <b>.env</b> files.</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
     <pre class="line-numbers"><code class="prism language-bash" data-prism>docker run -it --rm \


### PR DESCRIPTION
A frequent pitfall when migrating Appwrite versions is running the script in the wrong directory. 

This change aims to clarify the directory in which the command should be ran.