### PR TITLE
Remove extra $ symbols in commands

### DIFF
--- a/app/views/docs/command-line.phtml
+++ b/app/views/docs/command-line.phtml
@@ -22,9 +22,9 @@
         <h4>MacOS</h4>
         <p>Using <a href="https://brew.sh" target="_blank">Homebrew</a></p>
         <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-            <pre class="line-numbers"><code class="prism language-bash" data-prism>$ brew tap appwrite/sdk-for-cli https://github.com/appwrite/sdk-for-cli
-$ brew update
-$ brew install --HEAD appwrite</code></pre>
+            <pre class="line-numbers"><code class="prism language-bash" data-prism>brew tap appwrite/sdk-for-cli https://github.com/appwrite/sdk-for-cli
+brew update
+brew install --HEAD appwrite</code></pre>
         </div>
 
         <p>or terminal</p>


### PR DESCRIPTION
<img width="858" alt="Screen Shot 2022-03-19 at 3 01 52 PM" src="https://user-images.githubusercontent.com/29069505/159135035-aeae228b-81cc-4fde-835c-0ae137957b9b.png">

There were some `$` symbols in front of these commands, which is annoying cause you'll copy paste and realize bash is yelling at you about `$` is not a command.

This PR removes those symbols, a 6 character change :)