### PR TITLE
Added description for specifying endpoint before login with CLI

### DIFF
--- a/app/views/docs/command-line.phtml
+++ b/app/views/docs/command-line.phtml
@@ -61,7 +61,7 @@ brew install --HEAD appwrite</code></pre>
 <p>First, initialize your CLI by providing it your Appwrite server's endpoint</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite client --endpoint http://<API endpoint>/v1</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite client --endpoint https://[ENDPOINT]/v1</code></pre>
 </div>
 
 <p>Before you can use the CLI, you need to login to your Appwrite account using</p>

--- a/app/views/docs/command-line.phtml
+++ b/app/views/docs/command-line.phtml
@@ -58,6 +58,12 @@ brew install --HEAD appwrite</code></pre>
 
 <h2><a href="/docs/command-line#gettingStarted" id="gettingStarted">Getting Started</a></h2>
 
+<p>First, initialize your CLI by providing it your Appwrite server's endpoint</p>
+
+<div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite client --endpoint http://<API endpoint>/v1</code></pre>
+</div>
+
 <p>Before you can use the CLI, you need to login to your Appwrite account using</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">


### PR DESCRIPTION
When using a CLI for the first time, it's necessary to specify the endpoint of your Appwrite server. This should be explicitly mentioned in the docs.