### PR TITLE
Added a notice for passing in environment variables for API key and endpoint

### DIFF
--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -742,6 +742,11 @@ class MainActivity : AppCompatActivity() {
     </tbody>
 </table>
 
+<div class="notice">
+    <h3>Using an Appwrite SDK in Your Function</h3>
+    <p>Appwrite Server SDKs require an API key, an endpoint, and a project ID for authentication. Appwrite passes in your project ID with the environment variable 'APPWRITE_FUNCTION_PROJECT_ID', but not the endpoint and API key. If you need to use a Server SDK, you will need to add environment variables for your endpoint and API key in the 'Settings' tab of your function.</p>
+</div>
+
 <h2><a href="/docs/functions#monitorDebug" id="monitorDebug">Monitor & Debug</a></h2>
 
 <p>You can monitor your function execution usage stats and logs from your Appwrite console. To access your functions usage stats and logs, click the 'Usage' tab in your function dashboard.</p>


### PR DESCRIPTION
A commonly asked question on Discord and something that confused me initially is that API Key and Project ID are not passed in by default. This coupled with the slightly cryptic experience handling runtime logs and errors with the current function runtimes causes unnecessary confusion.

This PR adds a reminder to people to add these variables when using Appwrite Server SDKs.