### PR TITLE
Upgrade doc improvements

### DIFF
--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -33,7 +33,7 @@
     --entrypoint="install" \
     appwrite/appwrite:[NEXT MAJOR VERSION]</code></pre>
 </div>
-Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">`[NEXT MAJOR VERSION]`</span> with the next major version of Appwrite.
+<p>Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">[NEXT MAJOR VERSION]</span> with the next major version of Appwrite.</p>
 
 <h3><a href="/docs/installation#windows" id="windows">Windows</a></h3>
 
@@ -48,7 +48,7 @@ Recall that you can only upgrade to <b>immediately higher versions</b>. Replace 
     --entrypoint="install" ^
     appwrite/appwrite:[NEXT MAJOR VERSION]</code></pre>
         </div>
-        Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">`[NEXT MAJOR VERSION]`</span> with the next major version of Appwrite.
+        <p>Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">[NEXT MAJOR VERSION]</span> with the next major version of Appwrite.</p>
     </li>
     <li>
         <h4>PowerShell</h4>
@@ -60,11 +60,9 @@ Recall that you can only upgrade to <b>immediately higher versions</b>. Replace 
     --entrypoint="install" ,
     appwrite/appwrite:[NEXT MAJOR VERSION]</code></pre>
         </div>
-        Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">`[NEXT MAJOR VERSION]`</span> with the next major version of Appwrite.
+        <p>Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">[NEXT MAJOR VERSION]</span> with the next major version of Appwrite.</p>
     </li>
 </ul>
-
-<p>
 
 <p>This will pull the <b>docker-compose.yml</b> file for the new version and perform the installation. Once the setup completes, verify that you have the latest version of Appwrite.</p>
 

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -23,7 +23,7 @@
     </code></pre>
 </div>
 
-This is the parent directory, where you will find the <b>appwrite</b> directory, inside which contains the <b>docker-compose.yml</b> and <b>.env</b> files.</p>
+<p>This is the parent directory, where you will find the <b>appwrite</b> directory, inside which contains the <b>docker-compose.yml</b> and <b>.env</b> files.</p>
 
 <h3><a href="/docs/installation#unix" id="unix">Unix</a></h3>
 

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -33,7 +33,6 @@
     --entrypoint="install" \
     appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
 </div>
-<p>Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">[NEXT MAJOR VERSION]</span> with the next major version of Appwrite.</p>
 
 <h3><a href="/docs/installation#windows" id="windows">Windows</a></h3>
 
@@ -48,7 +47,6 @@
     --entrypoint="install" ^
     appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
         </div>
-        <p>Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">[NEXT MAJOR VERSION]</span> with the next major version of Appwrite.</p>
     </li>
     <li>
         <h4>PowerShell</h4>
@@ -60,7 +58,6 @@
     --entrypoint="install" ,
     appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
         </div>
-        <p>Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">[NEXT MAJOR VERSION]</span> with the next major version of Appwrite.</p>
     </li>
 </ul>
 

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -5,7 +5,9 @@
 
     <p>At present, we support migrations only to the immediately higher versions, i.e from 0.6 to 0.7 and 0.7 to 0.8 and so on. So if you're trying to migrate from 0.6 to 0.8, you will first need to migrate to 0.7 and then to 0.8</p>
 
-    <p>It is highly recommended to <a href="https://medium.com/sunkay-imho/docker-data-volumes-and-data-volume-containers-use-cases-abde84a10317" target="_blank" rel="noopener">backup your server</a> data and your <b>docker-compose.yml</b> file settings before running the migration tool. It is recommended to run the migration process on a dev instance and make sure your application is working well and that you have checked for any breaking changes in the new version <a href="https://github.com/appwrite/appwrite/blob/master/CHANGES.md" target="blank" rel="noopener">changelog.</a></p>
+    <p>You do not need to run migration when upgrading to a minor version. For example, going from 0.13.0 to 0.13.2 would not require running migration.</p>
+
+    <p>It is highly recommended to <a href="https://gist.github.com/Meldiron/47b5851663668102a676aff43c6341f7" target="_blank" rel="noopener">backup your server</a> data and your <b>docker-compose.yml</b> file settings before running the migration tool. It is recommended to run the migration process on a dev instance and make sure your application is working well and that you have checked for any breaking changes in the new version <a href="https://github.com/appwrite/appwrite/blob/master/CHANGES.md" target="blank" rel="noopener">changelog.</a></p>
 </div>
 
 <!-- <p>When updating to a new Appwrite version, make sure to run the <a href="/docs/installation">installation script for the new version</a> from the same location, you executed your original setup. This will allow the installation script to update your existing docker-compose.yml file. The correct location for execution is the parent directory of your existing appwrite directory.</p> -->
@@ -15,14 +17,15 @@
 <p> The first step is to install the latest version of Appwrite. Head to the directory where you ran your previous Appwrite install command. 
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>
-    parent_directory  <= you run the command in this directory
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>parent_directory  <= you run the command in this directory
     └── appwrite
         └── docker-compose.yml
     </code></pre>
 </div>
 
-This is the parent directory, where you will find the <b>appwrite</b> directory that contains the <b>docker-compose.yml</b> and <b>.env</b> files.</p>
+This is the parent directory, where you will find the <b>appwrite</b> directory, inside which contains the <b>docker-compose.yml</b> and <b>.env</b> files.</p>
+
+<h3><a href="/docs/installation#unix" id="unix">Unix</a></h3>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
     <pre class="line-numbers"><code class="prism language-bash" data-prism>docker run -it --rm \
@@ -32,6 +35,33 @@ This is the parent directory, where you will find the <b>appwrite</b> directory 
     appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
 </div>
 
+<h3><a href="/docs/installation#windows" id="windows">Windows</a></h3>
+
+<ul class="phases clear" data-ui-phases>
+    <li>
+        <h4>CMD</h4>
+
+        <div class="ide margin-bottom" data-lang="bash" data-lang-label="CMD">
+            <pre class="line-numbers"><code class="prism language-bash" data-prism>docker run -it --rm ^
+    --volume //var/run/docker.sock:/var/run/docker.sock ^
+    --volume "%cd%"/appwrite:/usr/src/code/appwrite:rw ^
+    --entrypoint="install" ^
+    appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
+        </div>
+
+    </li>
+    <li>
+        <h4>PowerShell</h4>
+
+        <div class="ide margin-bottom" data-lang="bash" data-lang-label="PowerShell">
+            <pre class="line-numbers"><code class="prism language-bash" data-prism>docker run -it --rm ,
+    --volume /var/run/docker.sock:/var/run/docker.sock ,
+    --volume ${pwd}/appwrite:/usr/src/code/appwrite:rw ,
+    --entrypoint="install" ,
+    appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
+        </div>
+    </li>
+</ul>
 
 <p>This will pull the <b>docker-compose.yml</b> file for the new version and perform the installation. Once the setup completes, verify that you have the latest version of Appwrite.</p>
 

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -14,7 +14,7 @@
 
 <!-- <p>The data migration tool will allow you to easily migrate your current Appwrite data to work with the new version. </p> -->
 
-<p> The first step is to install the latest version of Appwrite. Head to the directory where you ran your previous Appwrite install command. 
+<p> The first step is to install the latest version of Appwrite. Head to the directory where you ran your previous Appwrite install command. </p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
     <pre class="line-numbers"><code class="prism language-bash" data-prism>parent_directory  <= you run the command in this directory

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -64,6 +64,8 @@ Recall that you can only upgrade to <b>immediately higher versions</b>. Replace 
     </li>
 </ul>
 
+<p>
+
 <p>This will pull the <b>docker-compose.yml</b> file for the new version and perform the installation. Once the setup completes, verify that you have the latest version of Appwrite.</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -7,7 +7,7 @@
 
     <p>You do not need to run migration when upgrading to a minor version. For example, going from 0.13.0 to 0.13.2 would not require running migration.</p>
 
-    <p>It is highly recommended to <a href="https://gist.github.com/Meldiron/47b5851663668102a676aff43c6341f7" target="_blank" rel="noopener">backup your server</a> data before running the migration. It is recommended to run the migration process on a dev instance and make sure your application is working well and that you have checked for any breaking changes in the new version <a href="https://github.com/appwrite/appwrite/blob/master/CHANGES.md" target="_blank" rel="noopener">changelog.</a></p>
+    <p>It is highly recommended to <a href="https://gist.github.com/Meldiron/47b5851663668102a676aff43c6341f7" target="_blank" rel="noopener">backup your server</a> data before running the migration. It is recommended to run the migration process on a dev instance and make sure your application is working well and that you have checked for any breaking changes in the new version <a href="https://github.com/appwrite/appwrite/tags" target="_blank" rel="noopener">changelog.</a></p>
 </div>
 
 <!-- <p>When updating to a new Appwrite version, make sure to run the <a href="/docs/installation">installation script for the new version</a> from the same location, you executed your original setup. This will allow the installation script to update your existing docker-compose.yml file. The correct location for execution is the parent directory of your existing appwrite directory.</p> -->

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -17,10 +17,9 @@
 <p>The first step is to install the latest version of Appwrite. Head to the directory where you ran your previous Appwrite install command. </p>
 
 <div class="ide margin-bottom">
-    <pre class="line-numbers"><code class="prism" data-prism>parent_directory  <= you run the command in this directory
+    <pre class="line-numbers"><code class="prism" data-prism>parent_directory <= you run the command in this directory
     └── appwrite
-        └── docker-compose.yml
-    </code></pre>
+        └── docker-compose.yml</code></pre>
 </div>
 
 <p>This is the parent directory where you will find the <b>appwrite</b> directory, inside which contains the <b>docker-compose.yml</b> and <b>.env</b> files.</p>

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -7,7 +7,7 @@
 
     <p>You do not need to run migration when upgrading to a minor version. For example, going from 0.13.0 to 0.13.2 would not require running migration.</p>
 
-    <p>It is highly recommended to <a href="https://gist.github.com/Meldiron/47b5851663668102a676aff43c6341f7" target="_blank" rel="noopener">backup your server</a> data before running the migration tool. It is recommended to run the migration process on a dev instance and make sure your application is working well and that you have checked for any breaking changes in the new version <a href="https://github.com/appwrite/appwrite/blob/master/CHANGES.md" target="blank" rel="noopener">changelog.</a></p>
+    <p>It is highly recommended to <a href="https://gist.github.com/Meldiron/47b5851663668102a676aff43c6341f7" target="_blank" rel="noopener">backup your server</a> data before running the migration. It is recommended to run the migration process on a dev instance and make sure your application is working well and that you have checked for any breaking changes in the new version <a href="https://github.com/appwrite/appwrite/blob/master/CHANGES.md" target="_blank" rel="noopener">changelog.</a></p>
 </div>
 
 <!-- <p>When updating to a new Appwrite version, make sure to run the <a href="/docs/installation">installation script for the new version</a> from the same location, you executed your original setup. This will allow the installation script to update your existing docker-compose.yml file. The correct location for execution is the parent directory of your existing appwrite directory.</p> -->

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -16,8 +16,8 @@
 
 <p>The first step is to install the latest version of Appwrite. Head to the directory where you ran your previous Appwrite install command. </p>
 
-<div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>parent_directory  <= you run the command in this directory
+<div class="ide margin-bottom">
+    <pre class="line-numbers"><code class="prism" data-prism>parent_directory  <= you run the command in this directory
     └── appwrite
         └── docker-compose.yml
     </code></pre>

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -7,7 +7,7 @@
 
     <p>You do not need to run migration when upgrading to a minor version. For example, going from 0.13.0 to 0.13.2 would not require running migration.</p>
 
-    <p>It is highly recommended to <a href="https://gist.github.com/Meldiron/47b5851663668102a676aff43c6341f7" target="_blank" rel="noopener">backup your server</a> data and your <b>docker-compose.yml</b> file settings before running the migration tool. It is recommended to run the migration process on a dev instance and make sure your application is working well and that you have checked for any breaking changes in the new version <a href="https://github.com/appwrite/appwrite/blob/master/CHANGES.md" target="blank" rel="noopener">changelog.</a></p>
+    <p>It is highly recommended to <a href="https://gist.github.com/Meldiron/47b5851663668102a676aff43c6341f7" target="_blank" rel="noopener">backup your server</a> data before running the migration tool. It is recommended to run the migration process on a dev instance and make sure your application is working well and that you have checked for any breaking changes in the new version <a href="https://github.com/appwrite/appwrite/blob/master/CHANGES.md" target="blank" rel="noopener">changelog.</a></p>
 </div>
 
 <!-- <p>When updating to a new Appwrite version, make sure to run the <a href="/docs/installation">installation script for the new version</a> from the same location, you executed your original setup. This will allow the installation script to update your existing docker-compose.yml file. The correct location for execution is the parent directory of your existing appwrite directory.</p> -->

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -14,7 +14,7 @@
 
 <!-- <p>The data migration tool will allow you to easily migrate your current Appwrite data to work with the new version. </p> -->
 
-<p> The first step is to install the latest version of Appwrite. Head to the directory where you ran your previous Appwrite install command. </p>
+<p>The first step is to install the latest version of Appwrite. Head to the directory where you ran your previous Appwrite install command. </p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
     <pre class="line-numbers"><code class="prism language-bash" data-prism>parent_directory  <= you run the command in this directory
@@ -23,7 +23,7 @@
     </code></pre>
 </div>
 
-<p>This is the parent directory, where you will find the <b>appwrite</b> directory, inside which contains the <b>docker-compose.yml</b> and <b>.env</b> files.</p>
+<p>This is the parent directory where you will find the <b>appwrite</b> directory, inside which contains the <b>docker-compose.yml</b> and <b>.env</b> files.</p>
 
 <h3><a href="/docs/installation#unix" id="unix">Unix</a></h3>
 

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -31,7 +31,7 @@
     --volume /var/run/docker.sock:/var/run/docker.sock \
     --volume "$(pwd)"/appwrite:/usr/src/code/appwrite:rw \
     --entrypoint="install" \
-    appwrite/appwrite:[NEXT MAJOR VERSION]</code></pre>
+    appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
 </div>
 <p>Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">[NEXT MAJOR VERSION]</span> with the next major version of Appwrite.</p>
 
@@ -46,7 +46,7 @@
     --volume //var/run/docker.sock:/var/run/docker.sock ^
     --volume "%cd%"/appwrite:/usr/src/code/appwrite:rw ^
     --entrypoint="install" ^
-    appwrite/appwrite:[NEXT MAJOR VERSION]</code></pre>
+    appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
         </div>
         <p>Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">[NEXT MAJOR VERSION]</span> with the next major version of Appwrite.</p>
     </li>
@@ -58,7 +58,7 @@
     --volume /var/run/docker.sock:/var/run/docker.sock ,
     --volume ${pwd}/appwrite:/usr/src/code/appwrite:rw ,
     --entrypoint="install" ,
-    appwrite/appwrite:[NEXT MAJOR VERSION]</code></pre>
+    appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
         </div>
         <p>Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">[NEXT MAJOR VERSION]</span> with the next major version of Appwrite.</p>
     </li>

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -22,7 +22,7 @@
         └── docker-compose.yml</code></pre>
 </div>
 
-<p>This is the parent directory where you will find the <b>appwrite</b> directory, inside which contains the <b>docker-compose.yml</b> and <b>.env</b> files.</p>
+<p>This is the parent directory where you will find the <b>appwrite</b> directory, inside which there are <b>docker-compose.yml</b> and <b>.env</b> files.</p>
 
 <h3><a href="/docs/installation#unix" id="unix">Unix</a></h3>
 

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -3,7 +3,7 @@
 <div class="notice margin-bottom">
     <h3>A Note About Migration</h3>
 
-    <p>At present, we support migrations only to the immediately higher versions, i.e from 0.6 to 0.7 and 0.7 to 0.8 and so on. So if you're trying to migrate from 0.6 to 0.8, you will first need to migrate to 0.7 and then to 0.8</p>
+    <p>At present, we support migrations only to the <b>immediately higher versions</b>, i.e from 0.6 to 0.7 and 0.7 to 0.8 and so on. So if you're trying to migrate from 0.6 to 0.8, you will first need to migrate to 0.7 and then to 0.8</p>
 
     <p>You do not need to run migration when upgrading to a minor version. For example, going from 0.13.0 to 0.13.2 would not require running migration.</p>
 
@@ -31,8 +31,9 @@
     --volume /var/run/docker.sock:/var/run/docker.sock \
     --volume "$(pwd)"/appwrite:/usr/src/code/appwrite:rw \
     --entrypoint="install" \
-    appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
+    appwrite/appwrite:[NEXT MAJOR VERSION]</code></pre>
 </div>
+Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">`[NEXT MAJOR VERSION]`</span> with the next major version of Appwrite.
 
 <h3><a href="/docs/installation#windows" id="windows">Windows</a></h3>
 
@@ -45,9 +46,9 @@
     --volume //var/run/docker.sock:/var/run/docker.sock ^
     --volume "%cd%"/appwrite:/usr/src/code/appwrite:rw ^
     --entrypoint="install" ^
-    appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
+    appwrite/appwrite:[NEXT MAJOR VERSION]</code></pre>
         </div>
-
+        Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">`[NEXT MAJOR VERSION]`</span> with the next major version of Appwrite.
     </li>
     <li>
         <h4>PowerShell</h4>
@@ -57,8 +58,9 @@
     --volume /var/run/docker.sock:/var/run/docker.sock ,
     --volume ${pwd}/appwrite:/usr/src/code/appwrite:rw ,
     --entrypoint="install" ,
-    appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
+    appwrite/appwrite:[NEXT MAJOR VERSION]</code></pre>
         </div>
+        Recall that you can only upgrade to <b>immediately higher versions</b>. Replace <span class="tag">`[NEXT MAJOR VERSION]`</span> with the next major version of Appwrite.
     </li>
 </ul>
 


### PR DESCRIPTION
This PR addresses common issues brought up by community members when trying to follow the migration docs:
- Explicitly mention that this is only needed for going between major versions.
- Explicitly mention where in the file tree we should run our migration scripts.
- Add Windows syntax.
- Replace the backup article and use that of Matej's.
