### PR TITLE
attempt to quoted links redirect to the correct selected SDK

### DIFF
--- a/app/views/docs/service.phtml
+++ b/app/views/docs/service.phtml
@@ -291,7 +291,7 @@ $paramSDK = (!empty($sdk)) ? '?sdk='.$sdk : '';
             <div class="row responsive">
                 <div class="col span-7">
                     <h2 class="margin-bottom">
-                        <a href="/docs/<?php echo $this->escape($family); ?>/<?php echo $serviceName; ?>#<?php echo $operation['operationId']; ?>" id="<?php echo $operation['operationId']; ?>" class="references"><?php echo $this->escape($title); ?></a>
+                        <a href="/docs/<?php echo $this->escape($family); ?>/<?php echo $serviceName; ?>?sdk=<?php echo $this->escape($sdk); ?>#<?php echo $operation['operationId']; ?>" id="<?php echo $operation['operationId']; ?>" class="references"><?php echo $this->escape($title); ?></a>
                     </h2>
 
                     <div>


### PR DESCRIPTION
<img width="1792" alt="Screen Shot 2022-04-19 at 4 25 12 PM" src="https://user-images.githubusercontent.com/29069505/164089675-59fdcb7f-433c-4f3b-bcdc-d4bbd30ab6d5.png">

When a link to an endpoint like [Create User](https://2080-appwrite-homepage-azs3kdnll3c.ws-us34.gitpod.io/docs/server/users?sdk=dart-default#usersCreate) is clicked, it takes the user back to the default Web SDK even if they're currently viewing another SDK. 

This change aims to correct this behavior so quoting a specific endpoint to a specific SDK is possible.