### PR TITLE
Getting started explain plaforms

### DIFF
--- a/app/views/docs/command-line.phtml
+++ b/app/views/docs/command-line.phtml
@@ -91,6 +91,7 @@ brew install --HEAD appwrite</code></pre>
 <p>The CLI also handles the creation and deployment of Appwrite's Cloud Functions. You can initialize a new function using</p>
 
 <div class="notice margin-bottom"> 
+    <h3>Prerequisites</h3> 
     <p>Creating a new function using the Appwrite CLI requires <a href="https://git-scm.com/book/en/v2/Getting-Started-Installing-Git" target="_blank" rel="noopener">Git to be installed</a> on your machine.</p>
 </div>
 

--- a/app/views/docs/command-line.phtml
+++ b/app/views/docs/command-line.phtml
@@ -90,6 +90,10 @@ brew install --HEAD appwrite</code></pre>
 
 <p>The CLI also handles the creation and deployment of Appwrite's Cloud Functions. You can initialize a new function using</p>
 
+<div class="notice margin-bottom"> 
+    <p>Creating a new function using the Appwrite CLI requires <a href="https://git-scm.com/book/en/v2/Getting-Started-Installing-Git" target="_blank" rel="noopener">Git to be installed</a> on your machine.</p>
+</div>
+
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
     <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite init function
 ? What would you like to name your function? My Awesome Function
@@ -124,8 +128,8 @@ brew install --HEAD appwrite</code></pre>
     <h3>Self-Signed Certificates</h3> 
     <p>By default, requests to domains with self-signed SSL certificates (or no certificates) are disabled. If you trust the domain, you can bypass the certificate validation using</p>
     <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite client --selfSigned true</code></pre>
-</div>
+        <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite client --selfSigned true</code></pre>
+    </div>
 </div>
 
 <h3><a href="/docs/command-line#appwriteJSON" id="appwriteJSON">The appwrite.json File</a></h3>

--- a/app/views/docs/getting-started-for-web.phtml
+++ b/app/views/docs/getting-started-for-web.phtml
@@ -27,7 +27,7 @@ $demos = $platform['demos'] ?? [];
 
 <p>To init your SDK and interact with Appwrite services, you need to add a web platform to your project. To add a new platform, go to your Appwrite console, choose the project you created in the step before and click the 'Add Platform' button.</p>
 
-<p>From the options, choose to add a <b>web</b> platform and add your client app hostname. By adding your hostname to your project platform, you are allowing cross-domain communication between your project and the Appwrite API.</p>
+<p>From the options, choose to add a <b>web</b> platform and add your client app hostname. By adding your hostname to your project platform, you are allowing cross-domain communication between your project and the Appwrite API. This means, only web apps hosted on specified domains will be able to make requests to your Appwrite instance, preventing unwanted access from malicious actors.</p>
 
 <?php //TODO add console ui image here ?>
 


### PR DESCRIPTION
During office hours, a hacker was confused about what adding platforms does. Explaining to them that adding web platforms prevents unwanted cross-domain access helped answer his question and reassure him about security concerns.

To him, a security-conscious individual, this was an important piece of missing information.

This PR aims to add a missing explanation.