### PR TITLE
Explaining what adding a platform does.

### DIFF
--- a/app/views/docs/getting-started-for-android.phtml
+++ b/app/views/docs/getting-started-for-android.phtml
@@ -23,7 +23,7 @@ $androidVersion = (isset($versions['android'])) ? $versions['android'] : '';
 
 <h2><a href="/docs/getting-started-for-android#addProject" id="addProject">Add your Android Platform</a></h2>
 
-<p>To init your SDK and start interacting with Appwrite services, you need to add a new Android platform to your project. To add a new platform, go to your Appwrite console, choose the project you created in the step before, and click the 'Add Platform' button.</p>
+<p>To init your SDK and start interacting with Appwrite services, you need to add a new Android platform to your project. To add a new platform, go to your Appwrite console, choose the project you created in the step before, and click the 'Add Platform' button. Only API requests initiated from platforms added to your Appwrite project will be accepted. This prevents unauthorized apps from accessing your Appwrite project.</p>
 
 <p>From the options, choose to add a new <b>Android</b> platform and add add your app <u>name</u> and <u>package name</u>, your package name is generally the <b>applicationId</b> in your app-level <a href="https://github.com/appwrite/playground-for-android/blob/master/app/build.gradle#L12" target="_blank" rel="noopener">build.gradle</a> file. By registering your new app platform, you are allowing your app to communicate with the Appwrite API.</p>
 

--- a/app/views/docs/getting-started-for-apple.phtml
+++ b/app/views/docs/getting-started-for-apple.phtml
@@ -23,7 +23,7 @@ $appleVersion = $versions['apple'] ?? '';
 
 <h2><a href="/docs/getting-started-for-apple#addProject" id="addProject">Add your Apple Platform</a></h2>
 
-<p>To init your SDK and start interacting with Appwrite services, you need to add a new Apple platform to your project. To add a new platform, go to your Appwrite console, choose the project you created in the step before, and click the 'Add Platform' button.</p>
+<p>To init your SDK and start interacting with Appwrite services, you need to add a new Apple platform to your project. To add a new platform, go to your Appwrite console, choose the project you created in the step before, and click the 'Add Platform' button. Only API requests initiated from platforms added to your Appwrite project will be accepted. This prevents unauthorized apps from accessing your Appwrite project.</p>
 
 <p>From the options, choose to add a new <b>Apple</b> platform, select the iOS, macOS, watchOS or tvOS tab and add your app <u>name</u> and <u>bundle identifier</u>, Your bundle identifier can be found at the top of the `General` tab in your project settings, or in your `Info.plist` file. By registering your new app platform, you are allowing your app to communicate with the Appwrite API.</p>
 

--- a/app/views/docs/getting-started-for-flutter.phtml
+++ b/app/views/docs/getting-started-for-flutter.phtml
@@ -23,7 +23,7 @@ $version = (isset($versions['flutter'])) ? $versions['flutter'] : '';
 
 <h2><a href="/docs/getting-started-for-flutter#addYourPlatform" id="addYourPlatform">Add your Flutter Platform</a></h2>
 
-<p>To init your SDK and start interacting with Appwrite services, you need to add a new Flutter platform to your project. To add a new platform, go to your Appwrite console, choose the project you created in the step before, and click the 'Add Platform' button.</p>
+<p>To init your SDK and start interacting with Appwrite services, you need to add a new Flutter platform to your project. To add a new platform, go to your Appwrite console, choose the project you created in the step before, and click the 'Add Platform' button. Only API requests initiated from platforms added to your Appwrite project will be accepted. This prevents unauthorized apps from accessing your Appwrite project.</p>
 
 <p>From the options, choose to add a new <b>Flutter</b> platform and add your app credentials. Appwrite Flutter SDK currently supports building apps for Android, iOS, Linux, Mac OS, Web and Windows.</p>
 

--- a/app/views/docs/getting-started-for-web.phtml
+++ b/app/views/docs/getting-started-for-web.phtml
@@ -29,7 +29,7 @@ $demos = $platform['demos'] ?? [];
 
 <p>From the options, choose to add a <b>web</b> platform and add your client app hostname. By adding your hostname to your project platform, you are allowing cross-domain communication between your project and the Appwrite API. Only web apps hosted on domains specified in a web platform will be able to make requests to your Appwrite instance, preventing unwanted access from malicious actors.</p>
 
-<p>Web platfroms allow using wildcards in hostnames through the use of a <span class="tag">*</span>. For example, <span class="tag">*.example.com</span>. Avoiding using wildcards unless necessary to keep your Appwrite project secure.</p>
+<p>Web platfroms allow using wildcards in hostnames through the use of a <span class="tag">*</span> character. The wildcard character can be applied anywhere in a hostname, both <span class="tag">*.example.com</span> and <span class="tag">prod.*.example.com</span> are valid examples. Avoiding using wildcards unless necessary to keep your Appwrite project secure.</p>
 
 <?php //TODO add console ui image here ?>
 

--- a/app/views/docs/getting-started-for-web.phtml
+++ b/app/views/docs/getting-started-for-web.phtml
@@ -29,7 +29,7 @@ $demos = $platform['demos'] ?? [];
 
 <p>From the options, choose to add a <b>web</b> platform and add your client app hostname. By adding your hostname to your project platform, you are allowing cross-domain communication between your project and the Appwrite API. Only web apps hosted on domains specified in a web platform will be able to make requests to your Appwrite instance, preventing unwanted access from malicious actors.</p>
 
-<p>Web platfroms allow using wildcards in hostnames through the use of a <span class="tag">*</span> character. The wildcard character can be applied anywhere in a hostname, both <span class="tag">*.example.com</span> and <span class="tag">prod.*.example.com</span> are valid examples. Avoiding using wildcards unless necessary to keep your Appwrite project secure.</p>
+<p>Web platforms allow using wildcards in hostnames through a <span class="tag">*</span> character. The wildcard character can be applied anywhere in a hostname, both <span class="tag">*.example.com</span> and <span class="tag">prod.*.example.com</span> are valid examples. Avoid using wildcards unless necessary to keep your Appwrite project secure.</p>
 
 <?php //TODO add console ui image here ?>
 

--- a/app/views/docs/getting-started-for-web.phtml
+++ b/app/views/docs/getting-started-for-web.phtml
@@ -29,7 +29,7 @@ $demos = $platform['demos'] ?? [];
 
 <p>From the options, choose to add a <b>web</b> platform and add your client app hostname. By adding your hostname to your project platform, you are allowing cross-domain communication between your project and the Appwrite API. Only web apps hosted on domains specified in a web platform will be able to make requests to your Appwrite instance, preventing unwanted access from malicious actors.</p>
 
-<p>Web platfroms allow wildcards in hostnames through the use of <span class="tag">*</span>. For example, <span class="tag">*.example.com</span>. Avoiding using wildcards unless necessary to keep your Appwrite project secure.</p>
+<p>Web platfroms allow using wildcards in hostnames through the use of a <span class="tag">*</span>. For example, <span class="tag">*.example.com</span>. Avoiding using wildcards unless necessary to keep your Appwrite project secure.</p>
 
 <?php //TODO add console ui image here ?>
 

--- a/app/views/docs/getting-started-for-web.phtml
+++ b/app/views/docs/getting-started-for-web.phtml
@@ -29,7 +29,7 @@ $demos = $platform['demos'] ?? [];
 
 <p>From the options, choose to add a <b>web</b> platform and add your client app hostname. By adding your hostname to your project platform, you are allowing cross-domain communication between your project and the Appwrite API. Only web apps hosted on domains specified in a web platform will be able to make requests to your Appwrite instance, preventing unwanted access from malicious actors.</p>
 
-<p>Web platfroms allow wildcards in hostnames through the use of <span class="tag">*</span>. For example, <span class="tag">*.example.com</span> would allow requests from all domains that end in <span class="tag">example.com</span>. Avoiding using wildcards unless necessary to keep your Appwrite project secure.</p>
+<p>Web platfroms allow wildcards in hostnames through the use of <span class="tag">*</span>. For example, <span class="tag">*.example.com</span>. Avoiding using wildcards unless necessary to keep your Appwrite project secure.</p>
 
 <?php //TODO add console ui image here ?>
 

--- a/app/views/docs/getting-started-for-web.phtml
+++ b/app/views/docs/getting-started-for-web.phtml
@@ -27,7 +27,7 @@ $demos = $platform['demos'] ?? [];
 
 <p>To init your SDK and interact with Appwrite services, you need to add a web platform to your project. To add a new platform, go to your Appwrite console, choose the project you created in the step before and click the 'Add Platform' button.</p>
 
-<p>From the options, choose to add a <b>web</b> platform and add your client app hostname. By adding your hostname to your project platform, you are allowing cross-domain communication between your project and the Appwrite API. This means, only web apps hosted on specified domains will be able to make requests to your Appwrite instance, preventing unwanted access from malicious actors.</p>
+<p>From the options, choose to add a <b>web</b> platform and add your client app hostname. By adding your hostname to your project platform, you are allowing cross-domain communication between your project and the Appwrite API. Only web apps hosted on domains specified in a web platform will be able to make requests to your Appwrite instance, preventing unwanted access from malicious actors.</p>
 
 <?php //TODO add console ui image here ?>
 

--- a/app/views/docs/getting-started-for-web.phtml
+++ b/app/views/docs/getting-started-for-web.phtml
@@ -29,6 +29,8 @@ $demos = $platform['demos'] ?? [];
 
 <p>From the options, choose to add a <b>web</b> platform and add your client app hostname. By adding your hostname to your project platform, you are allowing cross-domain communication between your project and the Appwrite API. Only web apps hosted on domains specified in a web platform will be able to make requests to your Appwrite instance, preventing unwanted access from malicious actors.</p>
 
+<p>Web platfroms allow wildcards in hostnames through the use of <span class="tag">*</span>. For example, <span class="tag">*.example.com</span> would allow requests from all domains that end in <span class="tag">example.com</span>. Avoiding using wildcards unless necessary to keep your Appwrite project secure.</p>
+
 <?php //TODO add console ui image here ?>
 
 <h2><a href="/docs/getting-started-for-web#getSDK" id="getSDK">Get Appwrite Web SDK</a></h2>

--- a/app/views/docs/getting-started-for-web.phtml
+++ b/app/views/docs/getting-started-for-web.phtml
@@ -27,7 +27,7 @@ $demos = $platform['demos'] ?? [];
 
 <p>To init your SDK and interact with Appwrite services, you need to add a web platform to your project. To add a new platform, go to your Appwrite console, choose the project you created in the step before and click the 'Add Platform' button.</p>
 
-<p>From the options, choose to add a <b>web</b> platform and add your client app hostname. By adding your hostname to your project platform, you are allowing cross-domain communication between your project and the Appwrite API.</p>
+<p>From the options, choose to add a <b>web</b> platform and add your client app hostname. By adding your hostname to your project platform, you are allowing cross-domain communication between your project and the Appwrite API. This means, only web apps hosted on specified domains will be able to make requests to your Appwrite instance, preventing unwanted access from malicious actors.</p>
 
 <?php //TODO add console ui image here ?>
 

--- a/app/views/docs/getting-started-for-web.phtml
+++ b/app/views/docs/getting-started-for-web.phtml
@@ -29,7 +29,7 @@ $demos = $platform['demos'] ?? [];
 
 <p>From the options, choose to add a <b>web</b> platform and add your client app hostname. By adding your hostname to your project platform, you are allowing cross-domain communication between your project and the Appwrite API. Only web apps hosted on domains specified in a web platform will be able to make requests to your Appwrite instance, preventing unwanted access from malicious actors.</p>
 
-<p>Web platforms allow using wildcards in hostnames through a <span class="tag">*</span> character. The wildcard character can be applied anywhere in a hostname, both <span class="tag">*.example.com</span> and <span class="tag">prod.*.example.com</span> are valid examples. Avoid using wildcards unless necessary to keep your Appwrite project secure.</p>
+<p>Web platforms allow wildcard hostnames through a <span class="tag">*</span> character. The wildcard character can be applied anywhere in a hostname, both <span class="tag">*.example.com</span> and <span class="tag">prod.*.example.com</span> are valid examples. Avoid using wildcards unless necessary to keep your Appwrite project secure.</p>
 
 <?php //TODO add console ui image here ?>
 


### PR DESCRIPTION
During office hours, a hacker was confused about what adding platforms does. Explaining to them that adding web platforms prevents unwanted cross-domain access helped answer his question and reassure him about security concerns.

To him, a security-conscious individual, this was an important piece of missing information.

This PR aims to add a missing explanation.