### PR TITLE
Fix syntax errors in getting started example at the end

### DIFF
--- a/app/views/docs/getting-started-for-android.phtml
+++ b/app/views/docs/getting-started-for-android.phtml
@@ -130,7 +130,7 @@ val json = response.body?.string()
 val realtime = Realtime(client)
 
 realtime.subscribe("files", callback = { response ->
-    if(response.event === 'storage.files.create') {
+    if(response.event === "storage.files.create") {
         // Log when a new file is uploaded
         print(response.payload.toString());
     }

--- a/app/views/docs/getting-started-for-android.phtml
+++ b/app/views/docs/getting-started-for-android.phtml
@@ -103,7 +103,7 @@ val json = response.body?.string()</code></pre>
 val realtime = Realtime(client)
 
 realtime.subscribe("files", callback = { response ->
-    if(response.event === 'storage.files.create') {
+    if(response.event == "storage.files.create") {
         // Log when a new file is uploaded
         print(response.payload.toString());
     }
@@ -130,7 +130,7 @@ val json = response.body?.string()
 val realtime = Realtime(client)
 
 realtime.subscribe("files", callback = { response ->
-    if(response.event === "storage.files.create") {
+    if(response.event == "storage.files.create") {
         // Log when a new file is uploaded
         print(response.payload.toString());
     }

--- a/app/views/docs/getting-started-for-flutter.phtml
+++ b/app/views/docs/getting-started-for-flutter.phtml
@@ -209,11 +209,11 @@ final realtime = Realtime(client);
 final subscription = realtime.subscribe(['files']);
 
 subscription.stream.listen((response) {
-    if(response.event === 'storage.files.create') {
+    if(response.event == 'storage.files.create') {
         // Log when a new file is uploaded
         print(response.payload);
     }
-})
+});
 </code></pre>
 </div>
 

--- a/app/views/docs/getting-started-for-flutter.phtml
+++ b/app/views/docs/getting-started-for-flutter.phtml
@@ -173,11 +173,11 @@ final realtime = Realtime(client);
 final subscription = realtime.subscribe(['files']);
 
 subscription.stream.listen((response) {
-    if(response.event === 'storage.files.create') {
+    if(response.event == 'storage.files.create') {
         // Log when a new file is uploaded
         print(response.payload);
     }
-})
+});
 </code></pre>
 </div>
 


### PR DESCRIPTION
This fixes errors for Android and Flutter.

For Android:
- Fixes the use of single quotes for strings

For Flutter
- Missing semicolon
- Use of triple equal sign `===`, which is no longer supported.