### PR TITLE
Explain how to use Appwrite SDKs in Appwrite Functions

### DIFF
--- a/app/views/docs/command-line.phtml
+++ b/app/views/docs/command-line.phtml
@@ -4,6 +4,8 @@
 
 <p>The CLI is packaged both as an <a href="https://www.npmjs.com/package/appwrite-cli">npm module</a> as well as a <a href="https://github.com/appwrite/sdk-for-node-cli/releases/latest">standalone binary</a> for your operating system, making it completely dependency free, platform independent and language agnostic.</p>
 
+<p>If you plan to use the CLI to initialize new Cloud Functions, ensure that <a href="https://git-scm.com/book/en/v2/Getting-Started-Installing-Git" target="_blank" rel="noopener">Git is installed</a> on your machine.</p>
+
 <h3><a href="/docs/command-line#installWithNpm" id="installWithNpm">Install with NPM</a></h3>
 
 <p>If you have npm set up, run the command below to install the CLI</p>
@@ -89,11 +91,6 @@ brew install --HEAD appwrite</code></pre>
 <h3><a href="/docs/command-line#deployFunctions" id="deployFunctions">Deploying Cloud Functions</a></h3>
 
 <p>The CLI also handles the creation and deployment of Appwrite's Cloud Functions. You can initialize a new function using</p>
-
-<div class="notice margin-bottom"> 
-    <h3>Prerequisites</h3> 
-    <p>Creating a new function using the Appwrite CLI requires <a href="https://git-scm.com/book/en/v2/Getting-Started-Installing-Git" target="_blank" rel="noopener">Git to be installed</a> on your machine.</p>
-</div>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
     <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite init function

--- a/app/views/docs/command-line.phtml
+++ b/app/views/docs/command-line.phtml
@@ -91,6 +91,7 @@ brew install --HEAD appwrite</code></pre>
 <p>The CLI also handles the creation and deployment of Appwrite's Cloud Functions. You can initialize a new function using</p>
 
 <div class="notice margin-bottom"> 
+    <h3>Prerequisites</h3> 
     <p>Creating a new function using the Appwrite CLI requires <a href="https://git-scm.com/book/en/v2/Getting-Started-Installing-Git" target="_blank" rel="noopener">Git to be installed</a> on your machine.</p>
 </div>
 

--- a/app/views/docs/command-line.phtml
+++ b/app/views/docs/command-line.phtml
@@ -90,6 +90,10 @@ brew install --HEAD appwrite</code></pre>
 
 <p>The CLI also handles the creation and deployment of Appwrite's Cloud Functions. You can initialize a new function using</p>
 
+<div class="notice margin-bottom"> 
+    <p>Creating a new function using the Appwrite CLI requires <a href="https://git-scm.com/book/en/v2/Getting-Started-Installing-Git" target="_blank" rel="noopener">Git to be installed</a> on your machine.</p>
+</div>
+
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
     <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite init function
 ? What would you like to name your function? My Awesome Function
@@ -124,8 +128,8 @@ brew install --HEAD appwrite</code></pre>
     <h3>Self-Signed Certificates</h3> 
     <p>By default, requests to domains with self-signed SSL certificates (or no certificates) are disabled. If you trust the domain, you can bypass the certificate validation using</p>
     <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite client --selfSigned true</code></pre>
-</div>
+        <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite client --selfSigned true</code></pre>
+    </div>
 </div>
 
 <h3><a href="/docs/command-line#appwriteJSON" id="appwriteJSON">The appwrite.json File</a></h3>

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -749,9 +749,9 @@ class MainActivity : AppCompatActivity() {
 
 <h2><a href="/docs/functions#appwriteSDKInFunctions" id="appwriteSDKInFunctions">Appwrite SDKs in Functions</a></h2>
 
-<p>You can integrate Appwrite Functions with other Appwrite services by using the appropriate [Server SDK](https://appwrite.io/docs/getting-started-for-server) for your runtime. You can find starter code for your function's runtime in the [Appwrite Function Starter repository](https://github.com/appwrite/functions-starter).</p>
+<p>You can integrate Appwrite Functions with other Appwrite services by using the appropriate <a href="https://appwrite.io/docs/getting-started-for-server" target="_blank">Server SDK</a> for your runtime. You can find starter code for your function's runtime in the <a href="https://github.com/appwrite/functions-starter" target="_blank">Appwrite Function Starter repository</a>.</p>
 
-<p>To initialize a Server SDK in a function, you need to provide your Appwrite project's endpoint and an [API key](https://appwrite.io/docs/keys) as <b>Variables</b> in the <b>Settings</b> tab of your Function. The ID of your Appwrite project is passed in automatically as <span class="tag">APPWRITE_FUNCTION_PROJECT_ID</span>.</p>
+<p>To initialize a Server SDK in a function, you need to provide your Appwrite project's endpoint and an <a href="https://appwrite.io/docs/keys" target="_blank">API key</a> as <b>Variables</b> in the <b>Settings</b> tab of your Function. The ID of your Appwrite project is passed in automatically as <span class="tag">APPWRITE_FUNCTION_PROJECT_ID</span>.</p>
 
 <h2><a href="/docs/functions#monitorDebug" id="monitorDebug">Monitor & Debug</a></h2>
 

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -751,7 +751,7 @@ class MainActivity : AppCompatActivity() {
 
 <p>You can integrate Appwrite Functions with other Appwrite services by using the appropriate <a href="https://appwrite.io/docs/getting-started-for-server" target="_blank">Server SDK</a> for your runtime. You can find starter code for your function's runtime in the <a href="https://github.com/appwrite/functions-starter" target="_blank">Appwrite Function Starter repository</a>.</p>
 
-<p>To initialize a Server SDK in a function, you need to provide your Appwrite project's endpoint and an <a href="https://appwrite.io/docs/keys" target="_blank">API key</a> as <b>Variables</b> in the <b>Settings</b> tab of your Function. The ID of your Appwrite project is passed in automatically as <span class="tag">APPWRITE_FUNCTION_PROJECT_ID</span>.</p>
+<p>To initialize a Server SDK in a function, you need to provide your Appwrite project's endpoint and an <a href="https://appwrite.io/docs/keys" target="_blank">API key</a> as variables in the <b>Settings</b> tab of your Function. The ID of your Appwrite project is passed in automatically as <span class="tag">APPWRITE_FUNCTION_PROJECT_ID</span>.</p>
 
 <h2><a href="/docs/functions#monitorDebug" id="monitorDebug">Monitor & Debug</a></h2>
 

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -747,6 +747,12 @@ class MainActivity : AppCompatActivity() {
     <p>Appwrite Server SDKs require an API key, an endpoint, and a project ID for authentication. Appwrite passes in your project ID with the environment variable 'APPWRITE_FUNCTION_PROJECT_ID', but not the endpoint and API key. If you need to use a Server SDK, you will need to add environment variables for your endpoint and API key in the 'Settings' tab of your function.</p>
 </div>
 
+<h2><a href="/docs/functions#appwriteSDKInFunctions" id="appwriteSDKInFunctions">Appwrite SDKs in Functions</a></h2>
+
+<p>You can integrate Appwrite Functions with other Appwrite services by using the appropriate [Server SDK](https://appwrite.io/docs/getting-started-for-server) for your runtime. You can find starter code for your function's runtime in the [Appwrite Function Starter repository](https://github.com/appwrite/functions-starter).</p>
+
+<p>To initialize a Server SDK in a function, you need to provide your Appwrite project's endpoint and an [API key](https://appwrite.io/docs/keys) as <b>Variables</b> in the <b>Settings</b> tab of your Function. The ID of your Appwrite project is passed in automatically as <span class="tag">APPWRITE_FUNCTION_PROJECT_ID</span>.</p>
+
 <h2><a href="/docs/functions#monitorDebug" id="monitorDebug">Monitor & Debug</a></h2>
 
 <p>You can monitor your function execution usage stats and logs from your Appwrite console. To access your functions usage stats and logs, click the 'Usage' tab in your function dashboard.</p>

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -749,9 +749,9 @@ class MainActivity : AppCompatActivity() {
 
 <h2><a href="/docs/functions#appwriteSDKInFunctions" id="appwriteSDKInFunctions">Appwrite SDKs in Functions</a></h2>
 
-<p>You can integrate Appwrite Functions with other Appwrite services by using the appropriate <a href="https://appwrite.io/docs/getting-started-for-server" target="_blank">Server SDK</a> for your runtime. You can find starter code for your function's runtime in the <a href="https://github.com/appwrite/functions-starter" target="_blank">Appwrite Function Starter repository</a>.</p>
+<p>You can integrate Appwrite Functions with other Appwrite services by using the appropriate <a href="/docs/getting-started-for-server" target="_blank">Server SDK</a> for your runtime. You can find starter code for your function's runtime in the <a href="https://github.com/appwrite/functions-starter" target="_blank">Appwrite Function Starter repository</a>.</p>
 
-<p>To initialize a Server SDK in a function, you need to provide your Appwrite project's endpoint and an <a href="https://appwrite.io/docs/keys" target="_blank">API key</a> as variables in the <b>Settings</b> tab of your Function. The ID of your Appwrite project is passed in automatically as <span class="tag">APPWRITE_FUNCTION_PROJECT_ID</span>.</p>
+<p>To initialize a Server SDK in a function, you need to provide your Appwrite project's endpoint and an <a href="/docs/keys" target="_blank">API key</a> as variables in the <b>Settings</b> tab of your Function. The ID of your Appwrite project is passed in automatically as <span class="tag">APPWRITE_FUNCTION_PROJECT_ID</span>.</p>
 
 <h2><a href="/docs/functions#monitorDebug" id="monitorDebug">Monitor & Debug</a></h2>
 


### PR DESCRIPTION
A frequently asked question since 0.13 is how to use Appwrite SDKs in Appwrite Functions. This is frequently pointed out as missing in the documentation.

Furthermore, it's especially apparent that many (including myself) did not know endpoint and API keys needed to be passed in manually as variables in Appwrite Functions. This was noticed on Discord over launch and during the Hackathon.

This PR adds a snippet pointing to code examples and points out which variables must be added.