### PR TITLE
Flutter storage example updated to match 0.13.x API

### DIFF
--- a/app/views/docs/storage.phtml
+++ b/app/views/docs/storage.phtml
@@ -108,7 +108,7 @@ void main() { // Init SDK
   Future result = storage.createFile(
     bucketId: '[BUCKET_ID]',
     fileId: '[FILE_ID]',
-    file: await MultipartFile.fromPath('file', './path-to-files/image.jpg', 'image.jpg'),
+    file: InputFile(path: './path-to-files/image.jpg', filename: 'image.jpg'),
   );
 
   result


### PR DESCRIPTION
<img width="1131" alt="Screen Shot 2022-05-11 at 11 16 56 AM" src="https://user-images.githubusercontent.com/29069505/167885898-443001cb-4679-4fdb-8bd6-e3ff4933c09d.png">

The storage guide's Flutter example was out of date. The create file function now takes `InputFile` instead of `MultipartFile`. This is a simple PR to update the example to match the 0.13.x API.