### PR TITLE
Merge migration command blocks

### DIFF
--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -24,19 +24,20 @@
 
 <p>This is the parent directory where you will find the <b>appwrite</b> directory, inside which there are <b>docker-compose.yml</b> and <b>.env</b> files.</p>
 
-<h3><a href="/docs/installation#unix" id="unix">Unix</a></h3>
+<h3><a href="/docs/upgrade#upgrade-command" id="unix">Run The Migration</a></h3>
 
-<div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker run -it --rm \
+<ul class="phases clear" data-ui-phases>
+    
+    <li>
+    <h4>Unix</h4>
+    <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
+        <pre class="line-numbers"><code class="prism language-bash" data-prism>docker run -it --rm \
     --volume /var/run/docker.sock:/var/run/docker.sock \
     --volume "$(pwd)"/appwrite:/usr/src/code/appwrite:rw \
     --entrypoint="install" \
     appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
-</div>
-
-<h3><a href="/docs/installation#windows" id="windows">Windows</a></h3>
-
-<ul class="phases clear" data-ui-phases>
+    </div>
+    </li>
     <li>
         <h4>CMD</h4>
 

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -24,7 +24,7 @@
 
 <p>This is the parent directory where you will find the <b>appwrite</b> directory, inside which there are <b>docker-compose.yml</b> and <b>.env</b> files.</p>
 
-<h3><a href="/docs/upgrade#upgrade-command" id="unix">Run The Migration</a></h3>
+<h3><a href="/docs/upgrade#install-newest-version" id="install-new-version">Installing the Next Version</a></h3>
 
 <ul class="phases clear" data-ui-phases>
     
@@ -69,6 +69,8 @@
 </div>
 
 <p>Verify that the <b>STATUS</b> doesn't have any errors and all the <b>appwrite/appwrite</b> containers have version : <?php echo APP_VERSION_STABLE; ?></p>
+
+<h3><a href="/docs/upgrade#run-the-migration" id="migration">Running the Migration</a></h3>
 
 <p>We can now start the migration. Navigate to the <b>appwrite</b> directory where your <b>docker-compose.yml</b> is present and run the following command</p>
 


### PR DESCRIPTION
There is no reason to split the migration commands into blocks of UNIX vs windows instead of just a single block with tabs.

This PR makes the section look less busy.