### PR TITLE
Update links to demo functions

### DIFF
--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -715,4 +715,4 @@ $image = new View(__DIR__.'/../general/image.phtml');
 
 <h2><a href="/docs/functions#demosExamples" id="demosExamples">Demos & Examples</a></h2>
 
-<p>There are many Cloud Function demos and examples created by the Appwrite team and community in multiple coding languages. These examples are available at our <a href="https://github.com/appwrite/demos-for-functions" target="_blank" rel="noopener">demos repository</a> on GitHub. You can also submit your examples by submitting a <a href="https://github.com/appwrite/demos-for-functions/pulls" target="_blank" rel="noopener">pull-request</a>.</p>
+<p>There are many Cloud Function demos and examples created by the Appwrite team and community in multiple coding languages. These examples are available at our <a href="https://github.com/open-runtimes/examples" target="_blank" rel="noopener">examples repository</a> on GitHub. You can also submit your examples by submitting a <a href="https://github.com/open-runtimes/examples/pulls" target="_blank" rel="noopener">pull-request</a>.</p>


### PR DESCRIPTION
The demo-for-functions repo is for Appwrite 0.12 and older. Appwrite 0.13 
and newer use open runtimes so the documentation should point to the
open runtimes examples.

Closes: https://github.com/appwrite/appwrite/issues/3298