### PR TITLE
Install dependency section of functions guide is missing headings

### DIFF
--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -62,7 +62,7 @@ $runtimes = $this->getParam('runtimes', []);
   });
 };</code></pre>
         </div>
-        <b>Installing Dependencies</b>
+        <h3>Installing Dependencies</h3>
         <p>Include a <b>package.json</b> along with your function, and Appwrite handles the rest! The best practice is to make sure <b>node_modules</b> folder is <b>not</b> part of your tarball.</p>
         </div>
     </li>
@@ -94,7 +94,7 @@ return function ($req, $res) {
   ]);
 };</code></pre>
         </div>
-        <b>Installing Dependencies</b>
+        <h3>Installing Dependencies</h3>
         <p>Include a <b>composer.json</b> file in your function, make sure to require autoload.php from vendor folder, and Appwrite will handle the rest!. The best practice is to make sure <b>vendor</b> directory is <b>not</b> part of your tarball. </p>
     </div>
     </li>
@@ -124,7 +124,7 @@ def main(req, res):
     'trigger': trigger,
   })</code></pre>
         </div>
-        <b>Installing Dependencies</b>
+        <h3>Installing Dependencies</h3>
         <p>Include a <b>requirements.txt</b> file in your function, Appwrite will handle the rest!</p>
         </div>
     </li>
@@ -154,7 +154,7 @@ def main(req, res):
   })
 end</code></pre>
         </div>
-        <b>Installing Dependencies</b>
+        <h3>Installing Dependencies</h3>
         <p>Include a <b>Gemfile</b> in your function, Appwrite handles the rest!</p>
         </div>
     </li>
@@ -184,7 +184,7 @@ end</code></pre>
   });
 };</code></pre>
         </div>
-        <b>Installing Dependencies</b>
+        <h3>Installing Dependencies</h3>
         <p>No special steps are required for Deno, Appwrite handles everything!</p>
         </div>
     </li>
@@ -217,7 +217,7 @@ Future &lt;void&gt; start(final req, final res) async {
   });
 }</code></pre>
         </div>
-        <b>Installing Dependencies</b>
+        <h3>Installing Dependencies</h3>
         <p>Include a <b>pubspec.yaml</b> file with your function, Appwrite handles the rest!</p>
         </div>
     </li>
@@ -247,7 +247,7 @@ Future &lt;void&gt; start(final req, final res) async {
 }</code></pre>
         </div>
         <p>With Swift, your <b>entrypoint</b> can be empty since Appwrite automatically infers it from the location of your <b>main()</b> function. Just ensure that your cloud function has a <b>single declaration of main()</b> across your source files.</p>
-        <b>Installing Dependencies</b>
+        <h3>Installing Dependencies</h3>
         <p>Include a <b>Package.swift</b> file with your function, Appwrite handles the rest!</p>
         </div>
     </li>

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -62,7 +62,7 @@ $runtimes = $this->getParam('runtimes', []);
   });
 };</code></pre>
         </div>
-        <h3>Installing Dependencies</h3>
+        <p><b>Installing Dependencies</b></p>
         <p>Include a <b>package.json</b> along with your function, and Appwrite handles the rest! The best practice is to make sure <b>node_modules</b> folder is <b>not</b> part of your tarball.</p>
         </div>
     </li>
@@ -94,7 +94,7 @@ return function ($req, $res) {
   ]);
 };</code></pre>
         </div>
-        <h3>Installing Dependencies</h3>
+        <p><b>Installing Dependencies</b></p>
         <p>Include a <b>composer.json</b> file in your function, make sure to require autoload.php from vendor folder, and Appwrite will handle the rest!. The best practice is to make sure <b>vendor</b> directory is <b>not</b> part of your tarball. </p>
     </div>
     </li>
@@ -124,7 +124,7 @@ def main(req, res):
     'trigger': trigger,
   })</code></pre>
         </div>
-        <h3>Installing Dependencies</h3>
+        <p><b>Installing Dependencies</b></p>
         <p>Include a <b>requirements.txt</b> file in your function, Appwrite will handle the rest!</p>
         </div>
     </li>
@@ -154,7 +154,7 @@ def main(req, res):
   })
 end</code></pre>
         </div>
-        <h3>Installing Dependencies</h3>
+        <p><b>Installing Dependencies</b></p>
         <p>Include a <b>Gemfile</b> in your function, Appwrite handles the rest!</p>
         </div>
     </li>
@@ -184,7 +184,7 @@ end</code></pre>
   });
 };</code></pre>
         </div>
-        <h3>Installing Dependencies</h3>
+        <p><b>Installing Dependencies</b></p>
         <p>No special steps are required for Deno, Appwrite handles everything!</p>
         </div>
     </li>
@@ -217,7 +217,7 @@ Future &lt;void&gt; start(final req, final res) async {
   });
 }</code></pre>
         </div>
-        <h3>Installing Dependencies</h3>
+        <p><b>Installing Dependencies</b></p>
         <p>Include a <b>pubspec.yaml</b> file with your function, Appwrite handles the rest!</p>
         </div>
     </li>
@@ -247,7 +247,7 @@ Future &lt;void&gt; start(final req, final res) async {
 }</code></pre>
         </div>
         <p>With Swift, your <b>entrypoint</b> can be empty since Appwrite automatically infers it from the location of your <b>main()</b> function. Just ensure that your cloud function has a <b>single declaration of main()</b> across your source files.</p>
-        <h3>Installing Dependencies</h3>
+        <p><b>Installing Dependencies</b></p>
         <p>Include a <b>Package.swift</b> file with your function, Appwrite handles the rest!</p>
         </div>
     </li>


### PR DESCRIPTION
<img width="852" alt="Screen Shot 2022-05-31 at 2 44 56 PM" src="https://user-images.githubusercontent.com/29069505/171264641-06c01535-c24e-40a4-a0db-556586fed1d3.png">
The heading for "Installing Dependency" looks really weird!

This tries to fix the above mentioned issue.