### PR TITLE
Fix deploy command and add description for response size limit in functions

### DIFF
--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -322,7 +322,7 @@ Future &lt;void&gt; start(final req, final res) async {
     --functionId=6012cc93d5a7b \
     --activate=true \
     --entrypoint="index.js" \
-    --code="/myrepo/myfunction"</code></pre>
+    --code="."</code></pre>
         </div>
     </li>
     <li>
@@ -333,7 +333,7 @@ Future &lt;void&gt; start(final req, final res) async {
     --functionId=6012cc93d5a7b ^
     --activate=true ^
     --entrypoint="index.js" ^
-    --code="/myrepo/myfunction"</code></pre>
+    --code="."</code></pre>
         </div>
     </li>
     <li>
@@ -344,7 +344,7 @@ Future &lt;void&gt; start(final req, final res) async {
     --functionId=6012cc93d5a7b ,
     --activate=true ,
     --entrypoint="index.js" ,
-    --code="/myrepo/myfunction"</code></pre>
+    --code="."</code></pre>
         </div>
     </li>
 </ul>
@@ -517,6 +517,8 @@ class MainActivity : AppCompatActivity() {
 <p>Appwrite allows your project's end-users to execute Cloud Functions using client API or your client SDK. Execution is permitted to any user who has been granted the "execute" permission in your Cloud Functions settings page. The execution permission can accept any of the typical Appwrite <a href="/docs/permissions">permission types</a>.</p>
 
 <p>When triggering a Cloud Function execution from the client, your users will be limited to a specific amount of execution per minute to make sure your Appwrite server is not being abused. The default limit is 60 calls per 1 minute. You can edit this limit using the server <a href="/docs/environment-variables#functions">environment variables</a>.</p>
+
+<p>The response size of a Cloud Function is limited to 1MB. Large files or data volume should be handled using Appwrite's Database or Storage service.</p>
 
 <h2><a href="/docs/functions#ignoreFiles" id="ignoreFiles">Ignore Files</a></h2>
 

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -518,7 +518,7 @@ class MainActivity : AppCompatActivity() {
 
 <p>When triggering a Cloud Function execution from the client, your users will be limited to a specific amount of execution per minute to make sure your Appwrite server is not being abused. The default limit is 60 calls per 1 minute. You can edit this limit using the server <a href="/docs/environment-variables#functions">environment variables</a>.</p>
 
-<p>The response size of a Cloud Function is limited to 1MB. Large files or data volume should be handled using Appwrite's Database or Storage service.</p>
+<p>The response size of a Cloud Function is limited to 1MB. Reponses larger than 1MB should be handled using Appwrite's Database or Storage service.</p>
 
 <h2><a href="/docs/functions#ignoreFiles" id="ignoreFiles">Ignore Files</a></h2>
 


### PR DESCRIPTION
<img width="967" alt="Screen Shot 2022-06-01 at 2 58 41 PM" src="https://user-images.githubusercontent.com/29069505/171481593-9704ee11-a85c-4587-bb0d-0d4e569e154b.png">
Apparently the path given should always be `"."`, This clarifies it in the docs.

---

<img width="967" alt="Screen Shot 2022-06-01 at 3 12 40 PM" src="https://user-images.githubusercontent.com/29069505/171483785-01d2f341-9fda-4081-922b-b56bdee081c2.png">
Many were confused by random failures in their function because they tried to return file blobs or large amounts of data. It should be documented, but optimally we need better errors for this.
