### PR TITLE
Updates installation doc to mention dependency on v2

### DIFF
--- a/app/views/docs/certificates.phtml
+++ b/app/views/docs/certificates.phtml
@@ -12,7 +12,7 @@
 <p>If you're still struggling with your certificates, check the Appwrite certificates worker log. You can do that with the following command:</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker-compose logs appwrite-worker-certificates</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker compose logs appwrite-worker-certificates</code></pre>
 </div>
 
 <h2><a href="/docs/certificates#generationCycle" id="generationCycle">Generation Cycle</a></h2>
@@ -28,13 +28,13 @@
 <p>Since Appwrite generates and renews certificates automatically, a manual generation is seldom required. A manual generation can be useful when you hit the API limit and don't want to wait for the next maintenance cycle to renew the certificate. Use the following command to generate a certificate for your main domain:</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker-compose exec appwrite ssl</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker compose exec appwrite ssl</code></pre>
 </div>
 
 <p>If you want to generate a certificate for a specific domain, pass it as a parameter into the command:</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker-compose exec appwrite ssl domain="api.myapp.com"</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker compose exec appwrite ssl domain="api.myapp.com"</code></pre>
 </div>
 
 <h2>Dev Environment and Localhosts</h2>

--- a/app/views/docs/debugging.phtml
+++ b/app/views/docs/debugging.phtml
@@ -53,5 +53,5 @@ environment:
 <p>After you completed the change in the docker-compose.yml file, save it and run the following command to restart Appwrite with your new settings:</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker-compose up -d</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker compose up -d</code></pre>
 </div>

--- a/app/views/docs/email-delivery.phtml
+++ b/app/views/docs/email-delivery.phtml
@@ -35,7 +35,7 @@ _APP_SMTP_PASSWORD=YOUR-SMTP-PASSWORD</code></pre>
 <p>Once you've updated your .env file, you need to restart your Appwrite stack using the following command from your terminal:</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker-compose up -d</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker compose up -d</code></pre>
 </div>
 
 <h2><a href="/docs/email-delivery#debugging" id="debugging">Debugging</a></h2>
@@ -43,7 +43,7 @@ _APP_SMTP_PASSWORD=YOUR-SMTP-PASSWORD</code></pre>
 <p>If you are unable to send emails, there is most likely an issue with your integration. The first place to look for possible errors is the <b>Appwrite Emails Worker</b>. You can access the logs of this container using: 
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker-compose logs -f appwrite-worker-mails</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker compose logs -f appwrite-worker-mails</code></pre>
 </div>
 </p>
 
@@ -56,13 +56,13 @@ The next possible source of error is the configuration in your .env file. Make s
 <p>Another source of error could be that the environment variables have not been set in the appwrite container. You can check this using </p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker-compose exec appwrite-worker-mails vars</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker compose exec appwrite-worker-mails vars</code></pre>
 </div>
 
 <p>If this is the case, you can try rebuilding your appwrite stack using:</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker-compose up -d --build --force-recreate</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker compose up -d --build --force-recreate</code></pre>
 </div>
 
 <p>Now you can head over to your Appwrite console, logout from your account and try to recover your password or send invites to other team members from your Appwrite console using your newly configured SMTP provider.</p>

--- a/app/views/docs/environment-variables.phtml
+++ b/app/views/docs/environment-variables.phtml
@@ -12,7 +12,7 @@ $markdown->setSafeMode(true);
 <p>After editing your docker-compose.yml or .env files, you will need to restart your Appwrite stack by running the following compose command in your terminal:</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker-compose up -d</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker compose up -d</code></pre>
 </div>
 
 <p><b>All Options:</b></p>

--- a/app/views/docs/installation.phtml
+++ b/app/views/docs/installation.phtml
@@ -4,6 +4,8 @@
 
 <p>Appwrite was designed to run well on both small and large deployment. The minimum requirements to run Appwrite is as little as <b>1 CPU core</b> and <b>2GB of RAM</b>, and an operating system that supports Docker.</p>
 
+<p>As of version 0.14, Appwrite requires <a href="https://www.docker.com/blog/announcing-compose-v2-general-availability/" target="_blank" rel="noopener">Docker Compose Version 2</a>. To install Appwrite, make sure your Docker installation is updated to support Composer V2.</p>
+
 <div class="notice margin-bottom">
     <h3>Upgrading From Older Versions</h3>
     <p>If you are migrating from an older version of Appwrite, you need to follow the <a href="/docs/upgrade">migration instructions</a></p>

--- a/app/views/docs/installation.phtml
+++ b/app/views/docs/installation.phtml
@@ -4,7 +4,7 @@
 
 <p>Appwrite was designed to run well on both small and large deployment. The minimum requirements to run Appwrite is as little as <b>1 CPU core</b> and <b>2GB of RAM</b>, and an operating system that supports Docker.</p>
 
-<p>As of version 0.14, Appwrite requires <a href="https://www.docker.com/blog/announcing-compose-v2-general-availability/" target="_blank" rel="noopener">Docker Compose Version 2</a>. To install Appwrite, make sure your Docker installation is updated to support Composer V2.</p>
+<p>Appwrite requires <a href="https://docs.docker.com/compose/install/" target="_blank" rel="noopener">Docker Compose Version 2</a>. To install Appwrite, make sure your Docker installation is updated to support Composer V2.</p>
 
 <div class="notice margin-bottom">
     <h3>Upgrading From Older Versions</h3>
@@ -105,7 +105,7 @@
 <p>For advanced Docker users, the manual installation might seem more familiar. To setup Appwrite manually, download the Appwrite base <a href="https://gist.github.com/eldadfux/977869ff6bdd7312adfd4e629ee15cc5" target="_blank">docker-compose.yml and .env</a> files. After the download completes, update the different environment variables as you wish in the .env file and start the Appwrite stack using the following Docker command:</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker-compose up -d --remove-orphans</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker compose up -d --remove-orphans</code></pre>
 </div>
 
 <p>Once the Docker installation completes, go to your machine hostname or IP address on your browser to access the Appwrite console. Please notice that on non-linux native hosts the server might take a few minutes to start after installation completes.</p>
@@ -115,7 +115,7 @@
 <p>You can stop your Appwrite containers by using the following command executed from the same directory as your docker-compose.yml file.</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker-compose stop</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker compose stop</code></pre>
 </div>
 
 <h3><a href="/docs/installation#uninstall" id="manual">Uninstall</a></h3>
@@ -123,7 +123,7 @@
 <p>To stop and remove your Appwrite containers you can use the following command executed from the same directory as your docker-compose.yml file.</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker-compose down -v</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>docker compose down -v</code></pre>
 </div>
 
 <h2><a href="/docs/installation#learnMore" id="learnMore">Learn More</a></h2>

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -1,5 +1,7 @@
 <p>To upgrade your Appwrite server from an older version, you should use the Appwrite migration tool <b>after you have installed the new version</b>. The migration tool will adjust your Appwrite data to the new version's structure to make sure your Appwrite data is compatible with any internal changes. </p>
 
+<p>As of version 0.14, Appwrite requires <a href="https://www.docker.com/blog/announcing-compose-v2-general-availability/" target="_blank" rel="noopener">Docker Compose Version 2</a>. To install Appwrite, make sure your Docker installation is updated to support Composer V2.</p>
+
 <div class="notice margin-bottom">
     <h3>A Note About Migration</h3>
 
@@ -9,10 +11,6 @@
 
     <p>It is highly recommended to <a href="https://gist.github.com/Meldiron/47b5851663668102a676aff43c6341f7" target="_blank" rel="noopener">backup your server</a> data before running the migration. It is recommended to run the migration process on a dev instance and make sure your application is working well and that you have checked for any breaking changes in the new version <a href="https://github.com/appwrite/appwrite/tags" target="_blank" rel="noopener">changelog.</a></p>
 </div>
-
-<!-- <p>When updating to a new Appwrite version, make sure to run the <a href="/docs/installation">installation script for the new version</a> from the same location, you executed your original setup. This will allow the installation script to update your existing docker-compose.yml file. The correct location for execution is the parent directory of your existing appwrite directory.</p> -->
-
-<!-- <p>The data migration tool will allow you to easily migrate your current Appwrite data to work with the new version. </p> -->
 
 <p>The first step is to install the latest version of Appwrite. Head to the directory where you ran your previous Appwrite install command. </p>
 
@@ -76,7 +74,7 @@
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="Bash">
     <pre class="line-numbers"><code class="prism language-bash" data-prism>cd appwrite/
-docker-compose exec appwrite migrate</code></pre>
+docker compose exec appwrite migrate</code></pre>
 </div>
 
 <p>The data migration can take longer depending on the amount of data your Appwrite instance contains. The Appwrite migration command uses multi-threading to speed up the process, meaning that adding more CPU cores can help speed up the process.</p>

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -1,6 +1,6 @@
 <p>To upgrade your Appwrite server from an older version, you should use the Appwrite migration tool <b>after you have installed the new version</b>. The migration tool will adjust your Appwrite data to the new version's structure to make sure your Appwrite data is compatible with any internal changes. </p>
 
-<p>As of version 0.14, Appwrite requires <a href="https://www.docker.com/blog/announcing-compose-v2-general-availability/" target="_blank" rel="noopener">Docker Compose Version 2</a>. To install Appwrite, make sure your Docker installation is updated to support Composer V2.</p>
+<p>As of version 0.14, Appwrite requires <a href="https://docs.docker.com/compose/install/" target="_blank" rel="noopener">Docker Compose Version 2</a>. To upgrade Appwrite, make sure your Docker installation is updated to support Composer V2.</p>
 
 <div class="notice margin-bottom">
     <h3>A Note About Migration</h3>


### PR DESCRIPTION
For now, we'll be explicit about the change post 0.14 for sake of those migrating.

We can eventually remove this line as Docker Compose V2 is supposed to be the standard down the road.