### PR TITLE
Make copy writing across initialize SDK sections of mobile platform guides consistent!

### DIFF
--- a/app/views/docs/getting-started-for-android.phtml
+++ b/app/views/docs/getting-started-for-android.phtml
@@ -81,7 +81,7 @@ val client = Client(context)
 
 <p>Before sending any API calls to your new Appwrite project, make sure your Android device or emulator has network access to your Appwrite project's hostname or IP address.</p>
 
-<p>When connecting to a locally hosted Appwrite project from an emulator or a mobile device, you should use the private IP of the device running your Appwrite project as the hostname of the endpoint instead of localhost. You can also use a service like <a href="https://ngrok.com/" target="_blank" rel="noopener">ngrok</a> to proxy the Appwrite server.</p>
+<p>When connecting to a local self-hosted Appwrite project from an emulator or a mobile device, you should use the private IP of the device running your Appwrite project as the hostname of the endpoint instead of localhost. You can also use a service like <a href="https://ngrok.com/" target="_blank" rel="noopener">ngrok</a> to proxy the Appwrite server.</p>
 
 <h2><a href="/docs/getting-started-for-android#makeRequest" id="makeRequest">Make Your First Request</a></h2>
 

--- a/app/views/docs/getting-started-for-android.phtml
+++ b/app/views/docs/getting-started-for-android.phtml
@@ -79,9 +79,9 @@ val client = Client(context)
   .setSelfSigned(status: true) // For self signed certificates, only use for development</code></pre>
 </div>
 
-<p>Before starting to send any API calls to your new Appwrite instance, make sure your Android emulators has network access to the Appwrite server hostname or IP address.</p>
+<p>Before sending any API calls to your new Appwrite project, make sure your Android device or emulator has network access to your Appwrite project's hostname or IP address.</p>
 
-<p>When trying to connect to Appwrite from an emulator or a mobile device, localhost is the hostname for the device or emulator and not your local Appwrite instance. You should replace localhost with your private IP as the Appwrite endpoint's hostname. You can also use a service like <a href="https://ngrok.com/" target="_blank" rel="noopener">ngrok</a> to proxy the Appwrite API.</p>
+<p>When connecting to a locally hosted Appwrite project from an emulator or a mobile device, you should use the private IP of the device running your Appwrite project as the hostname of the endpoint instead of localhost. You can also use a service like <a href="https://ngrok.com/" target="_blank" rel="noopener">ngrok</a> to proxy the Appwrite server.</p>
 
 <h2><a href="/docs/getting-started-for-android#makeRequest" id="makeRequest">Make Your First Request</a></h2>
 

--- a/app/views/docs/getting-started-for-apple.phtml
+++ b/app/views/docs/getting-started-for-apple.phtml
@@ -110,9 +110,9 @@ let client = Client()
   .setSelfSigned(status: true) // For self signed certificates, only use for development</code></pre>
 </div>
 
-<p>If you're using a physical device instead of a simulator, ensure that you can access your Appwrite instance before sending API calls.</p>
+<p>Before sending any API calls to your new Appwrite project, make sure your device or iOS emulator has network access to your Appwrite project's hostname or IP address.</p>
 
-<p>When trying to connect to Appwrite from a physical device, localhost is the hostname for the device and not your local Appwrite instance. You should replace localhost with your private IP as the Appwrite endpoint's hostname. You can also use a service like <a href="https://ngrok.com/" target="_blank" rel="noopener">ngrok</a> to proxy the Appwrite API.</p>
+<p>When connecting to a locally hosted Appwrite project from an emulator or a mobile device, you should use the private IP of the device running your Appwrite project as the hostname of the endpoint instead of localhost. You can also use a service like <a href="https://ngrok.com/" target="_blank" rel="noopener">ngrok</a> to proxy the Appwrite server.</p>
 
 <h2><a href="/docs/getting-started-for-apple#makeRequest" id="makeRequest">Make Your First Request</a></h2>
 

--- a/app/views/docs/getting-started-for-apple.phtml
+++ b/app/views/docs/getting-started-for-apple.phtml
@@ -112,7 +112,7 @@ let client = Client()
 
 <p>Before sending any API calls to your new Appwrite project, make sure your device or iOS emulator has network access to your Appwrite project's hostname or IP address.</p>
 
-<p>When connecting to a locally hosted Appwrite project from an emulator or a mobile device, you should use the private IP of the device running your Appwrite project as the hostname of the endpoint instead of localhost. You can also use a service like <a href="https://ngrok.com/" target="_blank" rel="noopener">ngrok</a> to proxy the Appwrite server.</p>
+<p>When connecting to a local self-hosted Appwrite project from an emulator or a mobile device, you should use the private IP of the device running your Appwrite project as the hostname of the endpoint instead of localhost. You can also use a service like <a href="https://ngrok.com/" target="_blank" rel="noopener">ngrok</a> to proxy the Appwrite server.</p>
 
 <h2><a href="/docs/getting-started-for-apple#makeRequest" id="makeRequest">Make Your First Request</a></h2>
 

--- a/app/views/docs/getting-started-for-flutter.phtml
+++ b/app/views/docs/getting-started-for-flutter.phtml
@@ -143,7 +143,7 @@ client
 
 <p>Before sending any API calls to your new Appwrite project, make sure your mobile device or emulator has network access to your Appwrite project's hostname or IP address.</p>
 
-<p>When connecting to a locally hosted Appwrite project from an emulator or a mobile device, you should use the private IP of the device running your Appwrite project as the hostname of the endpoint instead of localhost. You can also use a service like <a href="https://ngrok.com/" target="_blank" rel="noopener">ngrok</a> to proxy the Appwrite server.</p>
+<p>When connecting to a local self-hosted Appwrite project from an emulator or a mobile device, you should use the private IP of the device running your Appwrite project as the hostname of the endpoint instead of localhost. You can also use a service like <a href="https://ngrok.com/" target="_blank" rel="noopener">ngrok</a> to proxy the Appwrite server.</p>
 
 <h2><a href="/docs/getting-started-for-flutter#makeRequest" id="makeRequest">Make Your First Request</a></h2>
 

--- a/app/views/docs/getting-started-for-flutter.phtml
+++ b/app/views/docs/getting-started-for-flutter.phtml
@@ -141,9 +141,9 @@ client
 </code></pre>
 </div>
 
-<p>Before starting to send any API calls to your new Appwrite instance, make sure your Android or iOS emulators has network access to the Appwrite server hostname or IP address.</p>
+<p>Before sending any API calls to your new Appwrite project, make sure your mobile device or emulator has network access to your Appwrite project's hostname or IP address.</p>
 
-<p>When trying to connect to your Appwrite instance running locally from an emulator or a mobile device, you should use the private IP of the device running your Appwrite server as the hostname of the endpoint instead of localhost. You can also use a service like <a href="https://ngrok.com/" target="_blank" rel="noopener">ngrok</a> to proxy the Appwrite server.</p>
+<p>When connecting to a locally hosted Appwrite project from an emulator or a mobile device, you should use the private IP of the device running your Appwrite project as the hostname of the endpoint instead of localhost. You can also use a service like <a href="https://ngrok.com/" target="_blank" rel="noopener">ngrok</a> to proxy the Appwrite server.</p>
 
 <h2><a href="/docs/getting-started-for-flutter#makeRequest" id="makeRequest">Make Your First Request</a></h2>
 


### PR DESCRIPTION
The writing across Flutter, iOS, and Android are inconsistent and at places unclear or contain grammatical errors. This aims to clarify the writing and make the content consistent.