### PR TITLE
Feat: Add query docs

### DIFF
--- a/app/views/docs/index.phtml
+++ b/app/views/docs/index.phtml
@@ -85,6 +85,7 @@ $cols = [
 
                 <ul class="margin-bottom">
                     <li><a href="/docs/pagination">Pagination</a></li>
+                    <li><a href="/docs/query">Query</a></li>
                     <li><a href="/docs/custom-domains">Custom Domains</a></li>
                     <li><a href="/docs/permissions">Permissions</a></li>
                     <li><a href="/docs/error-codes">Error Codes</a></li>

--- a/app/views/docs/query.phtml
+++ b/app/views/docs/query.phtml
@@ -1,0 +1,304 @@
+<p>
+Many Appwrite endpoints allows you to filter returned results through queries. Appwrite's SDKs include a <span class="tag">Query</span> class that helps construct query strings. This page documents all supported operations for Client SDKs. Server SDKs will behave similarly. 
+</p>
+
+<h2><a href="/docs/query#equal" id="equal">Equal</a></h2>
+<p>
+Returns results where the specified <b>attribute</b> is exactly equal to <b>value</b>.
+</p>
+<ul class="phases clear" data-ui-phases>
+    <li>
+        <h3>Web</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
+            <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
+const queryString = Query.equal(attribute, value);
+console.log(queryString);
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Flutter</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
+        <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.equal(attribute, value);
+print(queryString);
+        </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Android</h3>
+        <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
+            <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.equal(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>iOS</h3>
+        <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
+            <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
+let queryString = Query.equal(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+</ul>
+
+<h2><a href="/docs/query#not-equal" id="not-equal">Not Equal</a></h2>
+<p>
+Returns results where the specified <b>attribute</b> is not equal to <b>value</b>.
+</p>
+<ul class="phases clear" data-ui-phases>
+    <li>
+        <h3>Web</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
+            <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
+const queryString = Query.notEqual(attribute, value);
+console.log(queryString);
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Flutter</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
+        <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.notEqual(attribute, value);
+print(queryString);
+        </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Android</h3>
+        <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
+            <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.notEqual(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>iOS</h3>
+        <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
+            <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
+let queryString = Query.notEqual(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+</ul>
+
+<h2><a href="/docs/query#less-than" id="less-than">Less Than</a></h2>
+<p>
+Returns results where the specified <b>attribute</b> is less than <b>value</b>. Can be applied to strings where comparison is based on alphabetical order.
+</p>
+<ul class="phases clear" data-ui-phases>
+    <li>
+        <h3>Web</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
+            <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
+const queryString = Query.lesser(attribute, value);
+console.log(queryString);
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Flutter</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
+        <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.lesser(attribute, value);
+print(queryString);
+        </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Android</h3>
+        <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
+            <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.lesser(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>iOS</h3>
+        <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
+            <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
+let queryString = Query.lesser(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+</ul>
+
+<h2><a href="/docs/query#less-than-equal" id="less-than-equal">Less Than or Equal To</a></h2>
+<p>
+Returns results where the specified <b>attribute</b> is less than or equal to <b>value</b>. Can be applied to strings where comparison is based on alphabetical order.
+</p>
+<ul class="phases clear" data-ui-phases>
+    <li>
+        <h3>Web</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
+            <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
+const queryString = Query.lesserEqual(attribute, value);
+console.log(queryString);
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Flutter</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
+        <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.lesserEqual(attribute, value);
+print(queryString);
+        </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Android</h3>
+        <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
+            <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.lesserEqual(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>iOS</h3>
+        <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
+            <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
+let queryString = Query.lesserEqual(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+</ul>
+
+<h2><a href="/docs/query#greater-than" id="greater-than">Greater Than</a></h2>
+<p>
+Returns results where the specified <b>attribute</b> is greater than <b>value</b>. Can be applied to strings where comparison is based on alphabetical order.
+</p>
+<ul class="phases clear" data-ui-phases>
+    <li>
+        <h3>Web</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
+            <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
+const queryString = Query.greaterEqual(attribute, value);
+console.log(queryString);
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Flutter</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
+        <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.greaterEqual(attribute, value);
+print(queryString);
+        </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Android</h3>
+        <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
+            <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.greaterEqual(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>iOS</h3>
+        <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
+            <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
+let queryString = Query.greaterEqual(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+</ul>
+
+<h2><a href="/docs/query#greater-than" id="greater-than">Greater Than or Equal To</a></h2>
+<p>
+Returns results where the specified <b>attribute</b> is greater than or equal to <b>value</b>. Can be applied to strings where comparison is based on alphabetical order.
+</p>
+<ul class="phases clear" data-ui-phases>
+    <li>
+        <h3>Web</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
+            <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
+const queryString = Query.greaterEqual(attribute, value);
+console.log(queryString);
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Flutter</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
+        <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.greaterEqual(attribute, value);
+print(queryString);
+        </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Android</h3>
+        <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
+            <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.greaterEqual(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>iOS</h3>
+        <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
+            <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
+let queryString = Query.greaterEqual(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+</ul>
+
+<h2><a href="/docs/query#search" id="search">Search</a></h2>
+<p>
+Search returns results where the search term <b>value</b> matches or partially matches the string stored in <b>attribute</b>. For example, the search term "awesome" would match with the stored string "developers are awesome!". 
+</p>
+<ul class="phases clear" data-ui-phases>
+    <li>
+        <h3>Web</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
+            <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
+const queryString = Query.search(attribute, value);
+console.log(queryString);
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Flutter</h3>
+        <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
+        <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.search(attribute, value);
+print(queryString);
+        </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>Android</h3>
+        <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
+            <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
+String queryString = Query.search(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+    <li>
+        <h3>iOS</h3>
+        <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
+            <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
+let queryString = Query.search(attribute, value)
+print(queryString)
+            </code></pre>
+        </div>
+    </li>
+</ul>

--- a/app/views/docs/query.phtml
+++ b/app/views/docs/query.phtml
@@ -12,8 +12,7 @@ Returns results where the specified <b>attribute</b> is exactly equal to <b>valu
         <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
             <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
 const queryString = Query.equal(attribute, value);
-console.log(queryString);
-            </code></pre>
+console.log(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -21,8 +20,7 @@ console.log(queryString);
         <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
         <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.equal(attribute, value);
-print(queryString);
-        </code></pre>
+print(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -30,8 +28,7 @@ print(queryString);
         <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
             <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.equal(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
     <li>
@@ -39,8 +36,7 @@ print(queryString)
         <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
             <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
 let queryString = Query.equal(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
 </ul>
@@ -55,8 +51,7 @@ Returns results where the specified <b>attribute</b> is not equal to <b>value</b
         <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
             <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
 const queryString = Query.notEqual(attribute, value);
-console.log(queryString);
-            </code></pre>
+console.log(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -64,8 +59,7 @@ console.log(queryString);
         <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
         <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.notEqual(attribute, value);
-print(queryString);
-        </code></pre>
+print(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -73,8 +67,7 @@ print(queryString);
         <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
             <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.notEqual(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
     <li>
@@ -82,8 +75,7 @@ print(queryString)
         <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
             <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
 let queryString = Query.notEqual(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
 </ul>
@@ -98,8 +90,7 @@ Returns results where the specified <b>attribute</b> is less than <b>value</b>. 
         <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
             <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
 const queryString = Query.lesser(attribute, value);
-console.log(queryString);
-            </code></pre>
+console.log(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -107,8 +98,7 @@ console.log(queryString);
         <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
         <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.lesser(attribute, value);
-print(queryString);
-        </code></pre>
+print(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -116,8 +106,7 @@ print(queryString);
         <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
             <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.lesser(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
     <li>
@@ -125,8 +114,7 @@ print(queryString)
         <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
             <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
 let queryString = Query.lesser(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
 </ul>
@@ -141,8 +129,7 @@ Returns results where the specified <b>attribute</b> is less than or equal to <b
         <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
             <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
 const queryString = Query.lesserEqual(attribute, value);
-console.log(queryString);
-            </code></pre>
+console.log(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -150,8 +137,7 @@ console.log(queryString);
         <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
         <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.lesserEqual(attribute, value);
-print(queryString);
-        </code></pre>
+print(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -159,8 +145,7 @@ print(queryString);
         <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
             <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.lesserEqual(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
     <li>
@@ -168,8 +153,7 @@ print(queryString)
         <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
             <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
 let queryString = Query.lesserEqual(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
 </ul>
@@ -184,8 +168,7 @@ Returns results where the specified <b>attribute</b> is greater than <b>value</b
         <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
             <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
 const queryString = Query.greaterEqual(attribute, value);
-console.log(queryString);
-            </code></pre>
+console.log(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -193,8 +176,7 @@ console.log(queryString);
         <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
         <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.greaterEqual(attribute, value);
-print(queryString);
-        </code></pre>
+print(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -202,8 +184,7 @@ print(queryString);
         <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
             <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.greaterEqual(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
     <li>
@@ -211,8 +192,7 @@ print(queryString)
         <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
             <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
 let queryString = Query.greaterEqual(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
 </ul>
@@ -227,8 +207,7 @@ Returns results where the specified <b>attribute</b> is greater than or equal to
         <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
             <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
 const queryString = Query.greaterEqual(attribute, value);
-console.log(queryString);
-            </code></pre>
+console.log(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -236,8 +215,7 @@ console.log(queryString);
         <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
         <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.greaterEqual(attribute, value);
-print(queryString);
-        </code></pre>
+print(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -245,8 +223,7 @@ print(queryString);
         <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
             <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.greaterEqual(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
     <li>
@@ -254,8 +231,7 @@ print(queryString)
         <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
             <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
 let queryString = Query.greaterEqual(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
 </ul>
@@ -270,8 +246,7 @@ Search returns results where the search term <b>value</b> matches or partially m
         <div class="ide" data-lang="javascript" data-lang-label="Web SDK">
             <pre class="line-numbers"><code class="prism language-javascript" data-prism>import { Query } from "appwrite";
 const queryString = Query.search(attribute, value);
-console.log(queryString);
-            </code></pre>
+console.log(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -279,8 +254,7 @@ console.log(queryString);
         <div class="ide" data-lang="javascript" data-lang-label="Flutter SDK">
         <pre class="line-numbers"><code class="prism language-dart" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.search(attribute, value);
-print(queryString);
-        </code></pre>
+print(queryString);</code></pre>
         </div>
     </li>
     <li>
@@ -288,8 +262,7 @@ print(queryString);
         <div class="ide" data-lang="kotlin" data-lang-label="Android SDK">
             <pre class="line-numbers"><code class="prism language-kotlin" data-prism>import 'package:appwrite/appwrite.dart';
 String queryString = Query.search(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
     <li>
@@ -297,8 +270,7 @@ print(queryString)
         <div class="ide" data-lang="swift" data-lang-label="Apple SDK">
             <pre class="line-numbers"><code class="prism language-swift" data-prism>import Appwrite
 let queryString = Query.search(attribute, value)
-print(queryString)
-            </code></pre>
+print(queryString)</code></pre>
         </div>
     </li>
 </ul>


### PR DESCRIPTION
This file adds docs for the query class. This serves to display all available options, so users don't need to guess what query methods are available. This is a prerequisite for adding a more detailed explanation for the search parameter in various endpoints.