### PR TITLE
Feat: Deprecate CLI parameter

### DIFF
--- a/app/views/docs/command-line.phtml
+++ b/app/views/docs/command-line.phtml
@@ -82,12 +82,6 @@ brew install --HEAD appwrite</code></pre>
     <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite init collection</code></pre>
 </div>
 
-<p>The init command also comes with a convenient <span class="tag">--all</span> flag to perform both these steps at once using</p>
-
-<div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite init --all</code></pre>
-</div>
-
 <h3><a href="/docs/command-line#deployFunctions" id="deployFunctions">Deploying Cloud Functions</a></h3>
 
 <p>The CLI also handles the creation and deployment of Appwrite's Cloud Functions. You can initialize a new function using</p>
@@ -114,12 +108,6 @@ brew install --HEAD appwrite</code></pre>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
     <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite deploy collections</code></pre>
-</div>
-
-<p>The <b>deploy</b> command also comes with a convenient <span class="tag">--all</span> flag to deploy all your functions and collections at once.</p>
-
-<div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite deploy --all</code></pre>
 </div>
 
 <div class="notice margin-bottom"> 


### PR DESCRIPTION
Deprecate `--all` parameter for init and deploy, in favor of new -all parameters. More info on appwrite/appwrite PR.