### PR TITLE
Remove incorrectly added function variable

### DIFF
--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -751,12 +751,6 @@ class MainActivity : AppCompatActivity() {
         </tr>
         <tr>
             <td>
-                _APP_FUNCTIONS_RUNTIMES
-            </td>
-            <td>Enables function runtimes. Pass a list of runtime names separated by a comma, for example "node-16.0,php-8.0,python-3.9,ruby-3.0".</td>
-        </tr>
-        <tr>
-            <td>
                 APPWRITE_FUNCTION_RUNTIME_NAME
             </td>
             <td>Your function runtime name. Can be any of Appwrite supported execution runtimes.</td>


### PR DESCRIPTION
This removes a section in the environment variables section of the Functions guide that I accidentally introduced.

The environment variables are those passed into a function and not Appwrite environment variables.