### PR TITLE
We cannot use localhost in appwrite functions, this must be mentioned in docs

### DIFF
--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -828,6 +828,7 @@ class MainActivity : AppCompatActivity() {
 <div class="notice">
     <h3>Using an Appwrite SDK in Your Function</h3>
     <p>Appwrite Server SDKs require an API key, an endpoint, and a project ID for authentication. Appwrite passes in your project ID with the environment variable 'APPWRITE_FUNCTION_PROJECT_ID', but not the endpoint and API key. If you need to use a Server SDK, you will need to add environment variables for your endpoint and API key in the 'Settings' tab of your function.</p>
+    <p>If you are running a <b>local Appwrite instance</b>, you will need to pass in the machine's public IP instead of <span class="tag">'https://localhost/v1'</span>. Localhost inside the function's runtime container is not the same as localhost of your machine./p>
 </div>
 
 <h2><a href="/docs/functions#appwriteSDKInFunctions" id="appwriteSDKInFunctions">Appwrite SDKs in Functions</a></h2>


### PR DESCRIPTION
Localhost is not accessible inside a function's runtime. This can lead to a lot of unnecessary confusion.