### PR TITLE
Remove not equal from docs.

### DIFF
--- a/app/views/docs/databases.phtml
+++ b/app/views/docs/databases.phtml
@@ -315,10 +315,6 @@ func main() async throws{
             <td>Equal to.</td>
         </tr>
         <tr>
-            <td>notEqual</td>
-            <td>Not equal to.</td>
-        </tr>
-        <tr>
             <td>lesser</td>
             <td>Lesser than.</td>
         </tr>


### PR DESCRIPTION
Not Equal is not actually supported by Appwrite. This PR removes the docs for it, which is misleading.