### PR TITLE
Expand description for Appwrite Function timeouts and variables.

### DIFF
--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -648,6 +648,8 @@ class MainActivity : AppCompatActivity() {
 
 <p>When triggering a Cloud Function execution from the client, your users will be limited to a specific amount of execution per minute to make sure your Appwrite server is not being abused. The default limit is 60 calls per 1 minute. You can edit this limit using the server <a href="/docs/environment-variables#functions">environment variables</a>.</p>
 
+<p>Function execution times out after 15 seconds by default. This timeout can be configured per function in a function's settings or in <span class="tag">appwrite.json</span> up to a global maximum of 900 seconds. The global timeout maximum can be further increased by changing the <span class="tag">_APP_FUNCTIONS_TIMEOUT</span> environment variable.</p>
+
 <p>The response size of a Cloud Function is limited to 1MB. Reponses larger than 1MB should be handled using Appwrite's Databases or Storage service.</p>
 
 <h2><a href="/docs/functions#ignoreFiles" id="ignoreFiles">Ignore Files</a></h2>

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -652,7 +652,7 @@ class MainActivity : AppCompatActivity() {
 
 <p>You may find it necessary to disable or increase rate limits depending on use case. The API rate limit can be disabled by setting the <span class="tag">_APP_OPTIONS_ABUSE</span> variable to <span class="tag">disabled</span>.</p> 
 
-<p>The maximum configurable timeout of 900 seconds can also be increased by changing the <span class="tag">_APP_FUNCTIONS_TIMEOUT</span> environment variable. This environment variable updates the global configurable maximum for execution timeout, but does not change existing existing configured timeout for individual functions.</p>
+<p>The maximum configurable timeout of 900 seconds can also be increased by changing the <span class="tag">_APP_FUNCTIONS_TIMEOUT</span> environment variable. This environment variable updates the global configurable maximum for execution timeout, but does not change the existing configured timeout for individual functions.</p>
 
 <h2><a href="/docs/functions#ignoreFiles" id="ignoreFiles">Ignore Files</a></h2>
 

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -650,7 +650,7 @@ class MainActivity : AppCompatActivity() {
 
 <p>Function execution times out after 15 seconds by default. This timeout can be configured per function in a function's settings or in <span class="tag">appwrite.json</span> up to a global maximum of 900 seconds. The global timeout maximum can be further increased by changing the <span class="tag">_APP_FUNCTIONS_TIMEOUT</span> environment variable.</p>
 
-<p>The response size of a Cloud Function is limited to 1MB. Reponses larger than 1MB should be handled using Appwrite's Databases or Storage service.</p>
+<p>The response size of a Cloud Function is limited to 1MB. Responses larger than 1MB should be handled using Appwrite's Databases or Storage service.</p>
 
 <h2><a href="/docs/functions#ignoreFiles" id="ignoreFiles">Ignore Files</a></h2>
 

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -644,15 +644,13 @@ class MainActivity : AppCompatActivity() {
 
 <h3><a href="/docs/functions#abuseLimits" id="abuseLimits">Abuse and Limits</a></h3>
 
-<p>Appwrite allows your project's end-users to execute Cloud Functions using client API or your client SDK. Execution is permitted to any user who has been granted the "execute" permission in your Cloud Functions settings page. The execution permission can accept any of the typical Appwrite <a href="/docs/permissions">permission types</a>.</p>
+<p>Appwrite Functions can be executed using Client or Server SDKs. Client SDKs must be authenticated with an account that has been granted execution <a href="/docs/permissions">permissions</a> in the function's settings page. Server SDKs require an API key with the correct scopes</p>
 
-<p>To prevent abuse, each user is rate limited to making 60 calls per minute to the Functions API. Each execution has a default timeout of 15 seconds to prevent hanging functions from blocking resources. This timeout can be configured per function in a function's settings or in <span class="tag">appwrite.json</span> for up to 900 seconds.</p>
+<p>The Functions Service APIs are rate limited to 60 calls per minute per account when using a Client SDK. Learn more about <a href="docs/rate-limits">rate limiting</a>. The response size of a Cloud Function is limited to 1MB. Responses larger than 1MB should be handled using Appwrite's Databases or Storage service.</p>
 
-<p>The response size of a Cloud Function is limited to 1MB. Responses larger than 1MB should be handled using Appwrite's Databases or Storage service.</p>
+<p>Each execution has a default timeout of 15 seconds to prevent hanging functions from blocking resources. This timeout can be configured per function in a function's settings or in <span class="tag">appwrite.json</span> for up to 900 seconds.</p>
 
-<p>You may find it necessary to disable or increase rate limits depending on use case. The API rate limit can be disabled by setting the <span class="tag">_APP_OPTIONS_ABUSE</span> variable to <span class="tag">disabled</span>.</p> 
-
-<p>The maximum configurable timeout of 900 seconds can also be increased by changing the <span class="tag">_APP_FUNCTIONS_TIMEOUT</span> environment variable. This environment variable updates the global configurable maximum for execution timeout, but does not change the existing configured timeout for individual functions.</p>
+<p>The maximum configurable timeout can be increased by changing the <span class="tag">_APP_FUNCTIONS_TIMEOUT</span> environment variable. This environment variable changes the configurable maximum, but does not alter existing individual configurations.</p>
 
 <h2><a href="/docs/functions#ignoreFiles" id="ignoreFiles">Ignore Files</a></h2>
 

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -646,11 +646,11 @@ class MainActivity : AppCompatActivity() {
 
 <p>Appwrite allows your project's end-users to execute Cloud Functions using client API or your client SDK. Execution is permitted to any user who has been granted the "execute" permission in your Cloud Functions settings page. The execution permission can accept any of the typical Appwrite <a href="/docs/permissions">permission types</a>.</p>
 
-<p>When triggering a Cloud Function execution from the client, your users will be limited to a specific amount of execution per minute to make sure your Appwrite server is not being abused. The default limit is 60 calls per 1 minute. You can edit this limit using the server <a href="/docs/environment-variables#functions">environment variables</a>.</p>
-
-<p>Function execution times out after 15 seconds by default. This timeout can be configured per function in a function's settings or in <span class="tag">appwrite.json</span> up to a global maximum of 900 seconds. The global timeout maximum can be further increased by changing the <span class="tag">_APP_FUNCTIONS_TIMEOUT</span> environment variable.</p>
+<p>When triggering function execution from Client SDKs, each user is limited to 60 API calls per minute to prevent abuse. Each execution has a default time limit of 15 seconds to prevent hanging functions from blocking resources. This timeout can be configured per function in a function's settings or in <span class="tag">appwrite.json</span> up to 900 seconds.</p>
 
 <p>The response size of a Cloud Function is limited to 1MB. Responses larger than 1MB should be handled using Appwrite's Databases or Storage service.</p>
+
+<p>You may find it necessary to change the default limits depending on use case. The API rate limit can be temporarily disabled by setting the <span class="tag">_APP_OPTIONS_ABUSE</span> variable to <span class="tag">disabled</span>. The execution time limit maximum of 900 seconds can be further increased by changing the <span class="tag">_APP_FUNCTIONS_TIMEOUT</span> environment variable.</p>
 
 <h2><a href="/docs/functions#ignoreFiles" id="ignoreFiles">Ignore Files</a></h2>
 

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -644,13 +644,13 @@ class MainActivity : AppCompatActivity() {
 
 <h3><a href="/docs/functions#abuseLimits" id="abuseLimits">Abuse and Limits</a></h3>
 
-<p>Appwrite Functions can be executed using Client or Server SDKs. Client SDKs must be authenticated with an account that has been granted execution <a href="/docs/permissions">permissions</a> in the function's settings page. Server SDKs require an API key with the correct scopes</p>
+<p>Appwrite Functions can be executed using Client or Server SDKs. Client SDKs must be authenticated with an account that has been granted execution <a href="/docs/permissions">permissions</a> on the function's settings page. Server SDKs require an API key with the correct scopes.</p>
 
 <p>The Functions Service APIs are rate limited to 60 calls per minute per account when using a Client SDK. Learn more about <a href="docs/rate-limits">rate limiting</a>. The response size of a Cloud Function is limited to 1MB. Responses larger than 1MB should be handled using Appwrite's Databases or Storage service.</p>
 
-<p>Each execution has a default timeout of 15 seconds to prevent hanging functions from blocking resources. This timeout can be configured per function in a function's settings or in <span class="tag">appwrite.json</span> for up to 900 seconds.</p>
+<p>Each execution has a default timeout of 15 seconds to prevent hanging functions from blocking resources. This timeout can be configured per function on a function's settings page or in <span class="tag">appwrite.json</span> for up to 900 seconds.</p>
 
-<p>The maximum configurable timeout can be increased by changing the <span class="tag">_APP_FUNCTIONS_TIMEOUT</span> environment variable. This environment variable changes the configurable maximum, but does not alter existing individual configurations.</p>
+<p>The maximum configurable timeout can be increased by changing the <span class="tag">_APP_FUNCTIONS_TIMEOUT</span> environment variable. This environment variable changes the configurable maximum but does not alter existing individual configurations.</p>
 
 <h2><a href="/docs/functions#ignoreFiles" id="ignoreFiles">Ignore Files</a></h2>
 

--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -646,11 +646,13 @@ class MainActivity : AppCompatActivity() {
 
 <p>Appwrite allows your project's end-users to execute Cloud Functions using client API or your client SDK. Execution is permitted to any user who has been granted the "execute" permission in your Cloud Functions settings page. The execution permission can accept any of the typical Appwrite <a href="/docs/permissions">permission types</a>.</p>
 
-<p>When triggering function execution from Client SDKs, each user is limited to 60 API calls per minute to prevent abuse. Each execution has a default time limit of 15 seconds to prevent hanging functions from blocking resources. This timeout can be configured per function in a function's settings or in <span class="tag">appwrite.json</span> up to 900 seconds.</p>
+<p>To prevent abuse, each user is rate limited to making 60 calls per minute to the Functions API. Each execution has a default timeout of 15 seconds to prevent hanging functions from blocking resources. This timeout can be configured per function in a function's settings or in <span class="tag">appwrite.json</span> for up to 900 seconds.</p>
 
 <p>The response size of a Cloud Function is limited to 1MB. Responses larger than 1MB should be handled using Appwrite's Databases or Storage service.</p>
 
-<p>You may find it necessary to change the default limits depending on use case. The API rate limit can be temporarily disabled by setting the <span class="tag">_APP_OPTIONS_ABUSE</span> variable to <span class="tag">disabled</span>. The execution time limit maximum of 900 seconds can be further increased by changing the <span class="tag">_APP_FUNCTIONS_TIMEOUT</span> environment variable.</p>
+<p>You may find it necessary to disable or increase rate limits depending on use case. The API rate limit can be disabled by setting the <span class="tag">_APP_OPTIONS_ABUSE</span> variable to <span class="tag">disabled</span>.</p> 
+
+<p>The maximum configurable timeout of 900 seconds can also be increased by changing the <span class="tag">_APP_FUNCTIONS_TIMEOUT</span> environment variable. This environment variable updates the global configurable maximum for execution timeout, but does not change existing existing configured timeout for individual functions.</p>
 
 <h2><a href="/docs/functions#ignoreFiles" id="ignoreFiles">Ignore Files</a></h2>
 

--- a/app/views/docs/rate-limits.phtml
+++ b/app/views/docs/rate-limits.phtml
@@ -1,4 +1,6 @@
-<p>Some of Appwrite's API endpoints have a rate limit to avoid abuse or brute-force attack against Appwrite's REST API. Each Appwrite route documentation has information about any rate limits that might apply to them.</p>
+<p>Some of Appwrite's API endpoints have a rate limit to avoid abuse or brute-force attacks against Appwrite's REST API. Each Appwrite route documentation has information about any rate limits that might apply to them.</p>
+
+<p>Rate limits only apply to Client SDKs. Rate limits do not apply when accessing Appwrite with a Server SDK authenticated using an API key.</p>
 
 <p>You can check the returned HTTP headers of any API request to see your current rate limit status:</p>
 


### PR DESCRIPTION
<img width="853" alt="Screen Shot 2022-07-15 at 3 28 59 PM" src="https://user-images.githubusercontent.com/29069505/179297591-2b750d44-a227-45cb-9081-abe59a9ae69e.png">

Add a detailed description of how to increase timeout and global maximum for execution timeout.

Related to: https://github.com/appwrite/appwrite/pull/3550