### PR TITLE
Fix broken paragraph tag on permissions docs

### DIFF
--- a/app/views/docs/permissions.phtml
+++ b/app/views/docs/permissions.phtml
@@ -1,6 +1,6 @@
 <p>Appwrite permission mechanism offers a simple, yet flexible way to manage which users, teams, or roles can access a specific resource in your project, like documents and files.</p>
 
-p>Using permissions, you can decide that only <span class="tag">user A</span> and <span class="tag">user B</span> will have read and update access to a specific database document, while <span class="tag">user C</span> and <span class="tag">team X</span> will be the only ones with delete access.</p>
+<p>Using permissions, you can decide that only <span class="tag">user A</span> and <span class="tag">user B</span> will have read and update access to a specific database document, while <span class="tag">user C</span> and <span class="tag">team X</span> will be the only ones with delete access.</p>
 
 <p>As the name suggests, read permission allows a user to read a resource, create allows users to create new resources, update allows a user to make changes to a resource, and delete allows the user to remove the resource.</p>
 


### PR DESCRIPTION
## What does this PR do?

Fix broken `<p>` tag.

## Test Plan

Before:

![image](https://user-images.githubusercontent.com/1477010/190215739-28244986-4120-4392-87ad-63656489d2b7.png)

After manually tweaking the HTML on the page:

<img width="796" alt="image" src="https://user-images.githubusercontent.com/1477010/190215878-7a810770-21e1-47c7-9478-72ff2a1c4067.png">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes