### PR TITLE
Fix link to env vars on function docs

### DIFF
--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -683,7 +683,7 @@ suspend fun main() {
     </tbody>
 </table>
 
-<p>By default, the following runtimes are enabled: "node-16.0, php-8.0, python-3.9, ruby-3.0". To enable or disable runtimes, you can edit the <span class="tag">_APP_FUNCTIONS_RUNTIMES</span> <a href="/docs/functions#environmentVariables">environment variable</a>.</p>
+<p>By default, the following runtimes are enabled: "node-16.0, php-8.0, python-3.9, ruby-3.0". To enable or disable runtimes, you can edit the <span class="tag">_APP_FUNCTIONS_RUNTIMES</span> <a href="docs/environment-variables#functions">environment variable</a>.</p>
 
 <h2><a href="/docs/functions#environmentVariables" id="environmentVariables">Environment Variables</a></h2>
 


### PR DESCRIPTION
## What does this PR do?

The `_APP_FUNCTIONS_RUNTIMES` env var is actually an env var in the .env file, rather than variables provided to functions.

## Test Plan

None

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes