### PR TITLE
docs: typo in database.phtml

### DIFF
--- a/app/views/docs/databases.phtml
+++ b/app/views/docs/databases.phtml
@@ -541,7 +541,7 @@ func main() async throws {
         </tr>
         <tr>
             <td>unique</td>
-            <td>Unique Index which not allows duplicates.</td>
+            <td>Unique Index to disallow duplicates.</td>
         </tr>
         <tr>
             <td>fulltext</td>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to Appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

In the **Databases** page, something was poorly worded. ("Unique Index which not allows duplicates.") This just updates the wording, referencing the line above it.

It could have any of the following really if we wanted to keep it true to the original wording.

> Unique Index which…
> * will not
> * does not
> * won't
> * doesn't
> 
> …allow duplicates.

But I figured rewording it to "Unique Index to disallow duplicates." might've been simpler to match the wording of the previous key description. ("Plain Index to allow queries.")

## Test Plan

N/A

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

I've read it! I'm guessing this is because you're just using a generic issue template from your appwrite/.github, but the instructions here mostly apply to appwrite/appwrite since we're linked to that contribution guide.

They can actually throw someone off if their first contribution is to the appwrite/docs repo. ^-^'

For example, the `compose.json` file here does not define a `lint` or `format` command. Might be worth thinking if this repo should get its own issue template and/or CONTRIBUTING.md?
