### PR TITLE
docs: windows powershell installation fix

### DIFF
--- a/app/views/docs/functions.phtml
+++ b/app/views/docs/functions.phtml
@@ -467,10 +467,10 @@ static RuntimeResponse &main(const RuntimeRequest &req, RuntimeResponse &res) {
         <h3>PowerShell</h3>
 
         <div class="ide margin-bottom" data-lang="bash" data-lang-label="PowerShell">
-            <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite functions createDeployment ,
-    --functionId=6012cc93d5a7b ,
-    --activate=true ,
-    --entrypoint="index.js" ,
+            <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite functions createDeployment `
+    --functionId=6012cc93d5a7b `
+    --activate=true `
+    --entrypoint="index.js" `
     --code="."</code></pre>
         </div>
     </li>

--- a/app/views/docs/installation.phtml
+++ b/app/views/docs/installation.phtml
@@ -46,10 +46,10 @@
         <h4>PowerShell</h4>
 
         <div class="ide margin-bottom" data-lang="bash" data-lang-label="PowerShell">
-            <pre class="line-numbers"><code class="prism language-bash" data-prism>docker run -it --rm ,
-    --volume /var/run/docker.sock:/var/run/docker.sock ,
-    --volume ${pwd}/appwrite:/usr/src/code/appwrite:rw ,
-    --entrypoint="install" ,
+            <pre class="line-numbers"><code class="prism language-bash" data-prism>docker run -it --rm `
+    --volume /var/run/docker.sock:/var/run/docker.sock `
+    --volume ${pwd}/appwrite:/usr/src/code/appwrite:rw `
+    --entrypoint="install" `
     appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
         </div>
     </li>

--- a/app/views/docs/upgrade.phtml
+++ b/app/views/docs/upgrade.phtml
@@ -49,10 +49,10 @@
         <h4>PowerShell</h4>
 
         <div class="ide margin-bottom" data-lang="bash" data-lang-label="PowerShell">
-            <pre class="line-numbers"><code class="prism language-bash" data-prism>docker run -it --rm ,
-    --volume /var/run/docker.sock:/var/run/docker.sock ,
-    --volume ${pwd}/appwrite:/usr/src/code/appwrite:rw ,
-    --entrypoint="install" ,
+            <pre class="line-numbers"><code class="prism language-bash" data-prism>docker run -it --rm `
+    --volume /var/run/docker.sock:/var/run/docker.sock `
+    --volume ${pwd}/appwrite:/usr/src/code/appwrite:rw `
+    --entrypoint="install" `
     appwrite/appwrite:<?php echo APP_VERSION_STABLE; ?></code></pre>
         </div>
     </li>


### PR DESCRIPTION
## What does this PR do?

Updated the [installation command for Windows powershell](https://appwrite.io/docs/installation#windows), in powershell the new line is done via backticks(`). The current guide uses commas(,) for new line instead. 

Current 
```bash
docker run -it --rm ,
    --volume /var/run/docker.sock:/var/run/docker.sock ,
    --volume ${pwd}/appwrite:/usr/src/code/appwrite:rw ,
    --entrypoint="install" ,
    appwrite/appwrite:1.0.3
```
Updated with backticks. 
```bash
docker run -it --rm `
    --volume /var/run/docker.sock:/var/run/docker.sock `
    --volume ${pwd}/appwrite:/usr/src/code/appwrite:rw `
    --entrypoint="install" `
    appwrite/appwrite:1.0.3
```

This aligns with the current proper installation instructions given in the [appwrite repo.](https://github.com/appwrite/appwrite#windows)

## Related PRs and Issues

This was discussed and supposed to be fixed in this closed issue at [appwrite#315.](https://github.com/appwrite/appwrite/issues/315)
I tried alerting few weeks back but I guess with the hacktoberfest PR overload it might have been missed. As per that issue, the installation docs were on a private repo(in 2020) but today I saw that isn't the case and this repo exists :)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes