### PR TITLE
Clarify other database adapters are not yet supported

### DIFF
--- a/app/views/docs/databases.phtml
+++ b/app/views/docs/databases.phtml
@@ -21,8 +21,7 @@
 
 <h2><a href="/docs/databases#collection" id="collection">Create Your Collections</a></h2>
 <p>
-    Appwrite uses collections as containers of documents.
-    The terms collections and documents are used because the Appwrite JSON REST API resembles the API of a traditional NoSQL database. That said, internally, Appwrite can support both SQL and NoSQL database adapters like MariaDB, MySQL, or MongoDB. When working with an SQL adapter, Appwrite will treat your collections as tables and documents as rows on native SQL tables.
+    Appwrite uses collections as containers of documents. The terms collections and documents are used because the Appwrite JSON REST API resembles the API of a traditional NoSQL database. That said, internally, Appwrite will support both SQL and NoSQL database adapters like MariaDB, MySQL, or MongoDB. When working with an SQL adapter, Appwrite will treat your collections as tables and documents as rows on native SQL tables.
 </p>
 
 <p>


### PR DESCRIPTION
## What does this PR do?

Since MariaDB is currently the only DB adapter developers can use, it can be confusing to mention "Appwrite can support [...] MariaDB, MySQL, or MongoDB." This change will, hopefully, clarify support for other databases is coming soon.

## Test Plan

Not tested.

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes