### PR TITLE
Fix broken link to permissions from databases

### DIFF
--- a/app/views/docs/databases.phtml
+++ b/app/views/docs/databases.phtml
@@ -32,7 +32,7 @@
 
 <h3><a href="/docs/databases#permissions" id="permissions">Permissions</a></h3>
 <p>
-    Appwrite provides permissions to restrict access to documents at two levels, document and collection level. When a user has the appropriate type of <a href="/docs/permissions/">access permissions</a> granted at <b>either</b> the document or the collection level, they will be able to access or change the document. If the permission field is left empty, Client SDKs cannot access the document.
+    Appwrite provides permissions to restrict access to documents at two levels, document and collection level. When a user has the appropriate type of <a href="/docs/permissions">access permissions</a> granted at <b>either</b> the document or the collection level, they will be able to access or change the document. If the permission field is left empty, Client SDKs cannot access the document.
 </p>
 
 <h4>Document Level Permissions</h4>


### PR DESCRIPTION
## What does this PR do?

This changes the link from `/docs/permissions/` to `/docs/permissions` because the trailing slash causes a redirect to `https://appwrite.io/console`.

The problem link is here: https://appwrite.io/docs/databases#permissions

## Test Plan

Manually removing the trailing slash on https://appwrite.io/docs/databases#permissions

## Related PRs and Issues

User raised the problem in this issue:

* https://github.com/appwrite/appwrite/issues/4544#issuecomment-1315328925

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes