### PR TITLE
Hide unavailable options in version select

### DIFF
--- a/app/views/docs/service.phtml
+++ b/app/views/docs/service.phtml
@@ -184,6 +184,13 @@ if (!\function_exists('skipLanguage')) {
                                     </option>
                                 <?php endforeach; ?>
                             <?php endforeach; ?>
+                            
+                            <?php 
+                                // if version is lower than 1.2.x, don't show GraphQL and REST as selectable SDKs
+                                if (strcmp($version, "1.2.x") < 0) {
+                                    continue;
+                                }   
+                            ?>
 
                             <?php if (!skipLanguage($language, $family)): ?>
                                 <option disabled>──────────</option>
@@ -222,7 +229,9 @@ if (!\function_exists('skipLanguage')) {
                             $name = (isset($value['name'])) ? $value['name'] : '';
                             $selected = ($key === $version) ? ' selected' : '';
                             ?>
-                            <option value="<?php echo $this->escape($key); ?>"<?php echo ($key === $sdk) ? ' selected' : ''; ?><?php echo $selected; ?>>Version <?php echo $this->escape($key); ?></option>
+                            <?php if(!in_array($sdk, ['rest-default', 'graphql-default']) || strcmp($key, "1.2.x") >= 0): ?>
+                                <option value="<?php echo $this->escape($key); ?>"<?php echo ($key === $sdk) ? ' selected' : ''; ?><?php echo $selected; ?>>Version <?php echo $this->escape($key); ?></option>
+                            <?php endif; ?>
                         <?php endforeach; ?>
                     </select>
                 </form>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

You should not be able to select version 1.1.x and below when the GraphQL or REST sdks are selected.

Similarly, you should not be able to select version GraphQL or REST sdks if you selected 1.1.x and below.

This hides the incompatible version and SDK combinations.
## Test Plan
Here's a screencap of the effects

https://user-images.githubusercontent.com/29069505/209577943-87818bda-2468-42a3-b2c3-f96cb8a5140f.mov


