### PR TITLE
Fix Function Events in the Events Doc Page

### DIFF
--- a/app/views/docs/events.phtml
+++ b/app/views/docs/events.phtml
@@ -89,7 +89,7 @@ $events = $this->getParam('events', []);
         $description = $event['description'] ?? '';
         $model = $event['model'] ?? '';
     ?>
-    <?php if(str_starts_with($pattern, 'bucket')): ?>
+    <?php if(str_starts_with($pattern, 'functions')): ?>
     <tr>
         <td>
             <code><?php echo $this->escape($pattern); ?></code>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Function events were displaying bucket/storage events before. Now they display functions
## Test Plan
<img width="815" alt="Screenshot 2023-01-05 at 12 44 12 PM" src="https://user-images.githubusercontent.com/29069505/210846168-affe9cc9-858b-4e22-955c-9967bd4389e4.png">
<img width="815" alt="Screenshot 2023-01-05 at 12 44 17 PM" src="https://user-images.githubusercontent.com/29069505/210846170-c6cf1f64-d033-4e1d-865e-bc11ee788aee.png">
