### PR TITLE
Fix models with list of objects

### DIFF
--- a/app/views/docs/models.phtml
+++ b/app/views/docs/models.phtml
@@ -53,10 +53,6 @@ $example = function ($model, $models) use (&$example)
         else {
             $output[$key] = $value;
         }
-
-        if($type === 'array') {
-            $output[$key] = (\is_array($output[$key])) ? $output[$key] : [$output[$key]];
-        }
     }
 
     return $output;

--- a/app/views/docs/models.phtml
+++ b/app/views/docs/models.phtml
@@ -17,8 +17,8 @@ $example = function ($model, $models) use (&$example)
 
     foreach($properties as $key => $property) {
         $value = $property['x-example'] ?? null;
-        $isArray = $property['array'] ?? false;
         $type = $property['type'] ?? null;
+        $isArray = $type == 'array';
         $child = str_replace('#/definitions/', '', ($property['items']['$ref'] ?? ''));
 
         // We consider anyOf and oneOf the same in docs views

--- a/app/views/docs/models.phtml
+++ b/app/views/docs/models.phtml
@@ -36,7 +36,8 @@ $example = function ($model, $models) use (&$example)
         }
 
         if(!empty($child) && \array_key_exists($child, $models)) {
-            $output[$key] = $example($models[$child], $models);
+            $childExample = $example($models[$child], $models);
+            $output[$key] = $isArray ? [$childExample] : $childExample;
         }
         else if($isXOf) {
             if($isArray) {


### PR DESCRIPTION
## What does this PR do?

When we list objects, we check if the example provided is an array, if not we encapsulate it in a pair of `[]`.

The problem is, the original check returns true for associative arrays, causing all object arrays to not render correctly.

Closes: https://github.com/appwrite/appwrite/issues/3943

## Test Plan

Manual:

### Before 
---
<img width="776" alt="Screenshot 2022-12-30 at 3 48 09 PM" src="https://user-images.githubusercontent.com/29069505/210110631-3c345db9-d4c4-4c52-a310-8ca45805bada.png">

### After 
---

<img width="776" alt="Screenshot 2022-12-30 at 3 48 49 PM" src="https://user-images.githubusercontent.com/29069505/210110668-cca0da7c-6760-4bcf-9899-40f1824ce0d5.png">

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/3943

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes