### PR TITLE
Fix formatting of webhooks events paragraph

### DIFF
--- a/app/views/docs/webhooks.phtml
+++ b/app/views/docs/webhooks.phtml
@@ -150,7 +150,7 @@ let subscription = realtime.subscribe(channels: ["files"]) { message in
 </ul> -->
 
 <h2 id="events"><a href="/docs/events">Events</a></h2>
-Appwrite has events that fire when a resource changes. These events cover all Appwrite resources and can reflect create, update, and delete actions. You can specify one or many events to subscribe to with webhooks.
+<p>Appwrite has events that fire when a resource changes. These events cover all Appwrite resources and can reflect create, update, and delete actions. You can specify one or many events to subscribe to with webhooks.</p>
 <ul>
     <li class="margin-bottom"><a href="/docs/keys" rel="noopener"><i class="icon-angle-circled-right margin-start-negative-tiny margin-end-tiny"></i> Learn more about events</a></li>
 </ul>


### PR DESCRIPTION
## What does this PR do?

The text wasn't wrapped with paragraph tags so it looked smaller compared to the other paragraphs:

<img width="847" alt="image" src="https://user-images.githubusercontent.com/1477010/213533808-884c630a-0c88-42dd-bfcc-2ea6ef400790.png">

## Test Plan

Manual:

![image](https://user-images.githubusercontent.com/1477010/213534236-d4e6c4ed-e5f0-4578-addf-94231b280e14.png)

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes