### PR TITLE
Fix CLI database example with --databaseId

### DIFF
--- a/app/views/docs/command-line-commands.phtml
+++ b/app/views/docs/command-line-commands.phtml
@@ -110,13 +110,13 @@
 <p>To get a list of all your collections, you can use the <code>listCollections</code> command.</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite databases listCollections</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite databases listCollections --databaseId [DATABASE_ID]</code></pre>
 </div>
 
 <p>If you wish to parse the output from the CLI, you can request the CLI output in JSON format using the <code>--json</code> flag</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite databases listCollections --json</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite databases listCollections --databaseId [DATABASE_ID]--json</code></pre>
 </div>
 
 <p><b>Get a Collection</b></p>
@@ -124,7 +124,7 @@
 <p>To get more information on a particular collection, you can make use of the <code>getCollection</code> command and pass in the <code>collectionId</code>.</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite databases getCollection --collectionId 5ff468cfa32a0</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite databases getCollection --databaseId [DATABASE_ID] --collectionId [COLLECTION_ID]</code></pre>
 </div>
 
 <p><b>Create Document</b></p>
@@ -133,7 +133,7 @@
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
 <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite databases createDocument \
-    --collectionId [COLLECTION_ID] \
+    --databaseId [DATABASE_ID] --collectionId [COLLECTION_ID] \
     --documentId 'unique()' --data '{ "Name": "Iron Man" }' \
     --permissions 'read("any")' 'write("team:abc")' </code></pre>
 </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

We're missing the --databaseId option in the CLI examples.

## Test Plan
<img width="883" alt="Screenshot 2023-02-15 at 11 00 20 AM" src="https://user-images.githubusercontent.com/29069505/219082145-5949ad0f-fd92-4a27-a587-519b616a3914.png">
