### PR TITLE
 SMS Delivery Docs Fixes

### DIFF
--- a/app/views/docs/sms-delivery.phtml
+++ b/app/views/docs/sms-delivery.phtml
@@ -5,7 +5,7 @@
 <table cellspacing="0" cellpadding="0" border="0" class="full margin-bottom-large text-size-small vertical">
     <thead>
         <tr>
-            <th style="width: 60px"></th>
+            <th style="width: 80px"></th>
             <th>SMS Provider</th>
             <th>Create Account</th>
             <th>Get Credentials</th>
@@ -114,7 +114,7 @@
     </tr>
     <tr>
         <td>TeleSign</td>
-        <td><code>sms://[CUSTOMER ID]:[API KEY]:telesign</code></td>
+        <td><code>sms://[CUSTOMER ID]:[API KEY]@telesign</code></td>
         <td><code>[TELESIGN PHONE NUMBER]</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes the following:

- [ ] SMS provider table shows scroll on some devices
- [ ] SMS provider variable example for Telesign uses `:` instead of `@`

![image](https://user-images.githubusercontent.com/29069505/219699892-c0fa7b6b-b4ac-44dc-8a0b-1a755dc9d918.png)

## Test Plan
