### PR TITLE
Fix hyperlink for CLI configuration docs

### DIFF
--- a/app/views/docs/command-line.phtml
+++ b/app/views/docs/command-line.phtml
@@ -96,7 +96,7 @@ brew install --HEAD appwrite</code></pre>
 
 <p>If you get stuck anywhere, you can always use the <code>help</code> command to get the usage examples.</p>
 
-<h2><a href="/docs/command-line-ci#configuration" id="configuration">Configuration</a></h2>
+<h2><a href="/docs/command-line#configuration" id="configuration">Configuration</a></h2>
 
 <p>At any point, if you would like to change your server's endpoint, project ID, or self-signed certificate acceptance, use the <code>client</code> command.</p>
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

A hyperlink points to the wrong place. This fixes it.

## Test Plan

Not Applicable