### PR TITLE
changed commands for appwrite deploy

### DIFF
--- a/app/views/docs/command-line-deployment.phtml
+++ b/app/views/docs/command-line-deployment.phtml
@@ -50,7 +50,7 @@ The Apprite CLI allows you to create and deploy databases, collections, buckets,
 <p>The Appwrite CLI also helps you migrate your project's databases and collections from a development server to a production server. You can deploy all the databases and collections in your <a href="/docs/command-line-deployment#appwriteJSON">appwrite.json</a> file using:</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite deploy collections</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite deploy collection</code></pre>
 </div>
 
 <h2><a href="/docs/command-line-deployment#teams" id="teams">Deploying Teams</a></h2>
@@ -58,7 +58,7 @@ The Apprite CLI allows you to create and deploy databases, collections, buckets,
 <p>The Appwrite CLI can create teams to organize users. Teams can be used to grant access permissions to a group of users. <a href="/docs/permissions#permission-roles">Learn more about permissions</a>.</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite deploy teams</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite deploy team</code></pre>
 </div>
 
 
@@ -67,7 +67,7 @@ The Apprite CLI allows you to create and deploy databases, collections, buckets,
 <p>The Appwrite CLI allows you to configure and deploy buckets across projects. All the bucket's settings are available through the <a href="/docs/command-line-deployment#appwriteJSON">appwrite.json</a> file.</p>
 
 <div class="ide margin-bottom" data-lang="bash" data-lang-label="CLI">
-    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite deploy buckets</code></pre>
+    <pre class="line-numbers"><code class="prism language-bash" data-prism>appwrite deploy bucket</code></pre>
 </div>
 
 <h2><a href="/docs/command-line-deployment#avoidingConflicts" id="avoidingConflicts">Avoiding Conflicts</a></h2>


### PR DESCRIPTION
My appwrite CLI v2.0.2 gives me an error with the existing docs:

```
$ appwrite deploy collections  

Usage: index deploy [options] [command]

The deploy command provides a convenient wrapper for deploying your functions and collections.

Options:
  -h, --help            display help for command

Commands:
  function [options]    Deploy functions in the current directory.
  collection [options]  Deploy collections in the current project.
  bucket [options]      Deploy buckets in the current project.
  team [options]        Deploy teams in the current project.
```

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Fix an issue with the appwite CLI docs.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)