### PR TITLE
remove query limit and offset

### DIFF
--- a/app/views/docs/pagination.phtml
+++ b/app/views/docs/pagination.phtml
@@ -5,7 +5,7 @@
 <h2><a href="/docs/pagination#offset-pagination" id="offset-pagination">Offset Pagination</a></h2>
 <p>
     Using <code>Query.limit()</code> and <code>Query.offset()</code> you can achieve one of the most common approaches to pagination.
-    With <code>Query.limit()</code> you can define to how many documents that can be returned from one request, which can be up to a maximum of 100 documents.
+    With <code>Query.limit()</code> you can define to how many documents that can be returned from one request.
     The <code>Query.offset()</code> is simply the number of records you wish to skip before selecting records.
 </p>
 
@@ -145,7 +145,7 @@ func main() async throws {
 </ul>
 
 <p>
-    The maximum offset is <b>5000</b>, since the request gets slower as the number of records increases because the database has to read up to the offset number of rows to know where it should start selecting data.
+    The request gets slower as the number of records increases because the database has to read up to the offset number of rows to know where it should start selecting data.
     Also when there is data added in high frequency - the individual pages might skip results.
 </p>
 


### PR DESCRIPTION
the query limit and offset maximum were removed in appwrite 1.3.0 (see pr https://github.com/appwrite/appwrite/pull/5143)