### PR TITLE
Wildcards can't be used in channel

### DIFF
--- a/app/views/docs/realtime.phtml
+++ b/app/views/docs/realtime.phtml
@@ -493,7 +493,9 @@ subscription.close()</code></pre>
 
 <h2><a href="/docs/realtime#channels" id="channels">Channels</a></h2>
 
-<p>A list of all channels available you can subscribe to:</p>
+<p>
+    You can subscribe to changes in a specific area of Appwrite by subscribing to channels. You can subscribe to specific resources by replacing <code>[ID]</code> with the desired resource's ID or subscribe to all resources of the same type with the wildcard character <code>*</code>.
+</p>
 
 <table class="full text-size-small">
     <thead>
@@ -514,9 +516,9 @@ subscription.close()</code></pre>
 
 <h2><a href="/docs/realtime#custom-endpoint" id="custom-endpoint">Custom Endpoint</a></h2>
 
-<p>The SDK will guess the endpoint of the Realtime API when setting the endpoint of your Appwrite instance. If you are running Appwrite with a custom proxy and changed the route of the Realtime API, you can call the <b>setEndpointRealtime</b> method on the Client SDK and set your new endpoint value.</p>
+<p>The SDK will guess the endpoint of the Realtime API when setting the endpoint of your Appwrite instance. If you are running Appwrite with a custom proxy and changed the route of the Realtime API, you can call the <code>setEndpointRealtime</code> method on the Client SDK and set your new endpoint value.</p>
 
-<p>By default the endpoint is <b>wss://cloud.appwrite.io/v1/realtime</b>.</p>
+<p>By default the endpoint is <code>wss://cloud.appwrite.io/v1/realtime</code>.</p>
 
 <ul class="phases clear" data-ui-phases>
     <li>

--- a/app/views/docs/realtime.phtml
+++ b/app/views/docs/realtime.phtml
@@ -493,9 +493,7 @@ subscription.close()</code></pre>
 
 <h2><a href="/docs/realtime#channels" id="channels">Channels</a></h2>
 
-<p>
-    You can subscribe to changes in a specific area of Appwrite by subscribing to channels. You can subscribe to specific resources by replacing <code>[ID]</code> with the desired resource's ID or subscribe to all resources of the same type with the wildcard character <code>*</code>.
-</p>
+<p>A list of all channels available you can subscribe to. IDs cannot be wildcards.</p>
 
 <table class="full text-size-small">
     <thead>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Wild cards can't be used for channels. This clarifies it. 

Maybe we need to also add validation and a good error for it.
## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)