### PR TITLE
Ensure API endpoints have required params first

### DIFF
--- a/app/views/docs/service.phtml
+++ b/app/views/docs/service.phtml
@@ -305,13 +305,6 @@ if (!\function_exists('skipLanguage')) {
         $security = $operation['security'][0] ?? '';
         $platformsList = (isset($operation['platforms'])) ? array_map(function($node) {return 'example-for-'.$node;}, $operation['platforms']) : [];
 
-        usort($parameters, function ($a, $b) {
-            $x = (isset($a['required'])) ? $a['required'] : false;
-            $y = (isset($b['required'])) ? $b['required'] : false;
-
-            return $y - $x;
-        });
-
         $rateKey = (is_array($rateKey)) ? implode(',', $rateKey) : $rateKey;
 
         $rateKey = array_map(function($element)
@@ -335,6 +328,13 @@ if (!\function_exists('skipLanguage')) {
                 }
             }
         }
+
+        usort($parameters, function ($a, $b) {
+            $x = (isset($a['required'])) ? $a['required'] : false;
+            $y = (isset($b['required'])) ? $b['required'] : false;
+
+            return $y - $x;
+        });
 
         ?>
         <div class="margin-bottom-large x-function" data-ls-attrs="class=margin-bottom-large x-function <?php echo implode(' ', $platformsList); ?>">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Our SDKs sort API params to make required params first (because most languages need to have required params before optional). This fixes a bug where we weren't properly sorting params in the body/payload.

Closes: https://github.com/appwrite/appwrite/issues/5676

## Test Plan

Manual:

![image](https://github.com/appwrite/docs/assets/1477010/5bd31329-2ed4-445b-842d-79a35dd7b276)


## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/5676

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes