### PR TITLE
Further rebrand from Akamai

### DIFF
--- a/app/views/docs/configuration.phtml
+++ b/app/views/docs/configuration.phtml
@@ -40,7 +40,7 @@
 <h2><a href="#storage" id="storage">Storage Adaptors</a></h2>
 <p>Appwrite's Storage Service can be configured to store files locally, or with self-hosted and cloud storage services. By default, Appwrite's Storage Service <b>stores files on your server's local storage</b>. If you expect large volumes of data or the need to have scalable data storage, you may choose to use a separate storage service.</p>
 
-<p>Appwrite supports AWS S3, Digital Ocean Spaces, Backblaze, Linode, and Wasabi as storage adaptors. Some of these services can be self-hosted, just like Appwrite.</p>
+<p>Appwrite supports AWS S3, Digital Ocean Spaces, Backblaze, Akamai Object Storage, and Wasabi as storage adaptors. Some of these services can be self-hosted, just like Appwrite.</p>
 
 <p>You can select which storage adaptor to use by setting the <code>_APP_STORAGE_DEVICE</code> environment variable. Valid values are <code>local</code>, <code>s3</code>, <code>dospaces</code>, <code>backblaze</code>, <code>linode</code> and <code>wasabi</code>. Each storage adaptor requires its own set of additional environment variables to configure.</p>
 

--- a/app/views/docs/self-hosting.phtml
+++ b/app/views/docs/self-hosting.phtml
@@ -111,7 +111,7 @@
                 <img src="/images-ee/one-click/dark/akamai.svg" alt="Logo" height="30" class="force-dark sdk-logo margin-start margin-end" />
             </td>
             <td>
-                Akamai
+                Akamai Compute
             </td>
             <td>
                 <a href="https://www.linode.com/marketplace/apps/appwrite/appwrite/" target="_blank" rel="noopener">Click to Install</a>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Update after linode/akamai acquisition and rebrand:

Linode Storage is now -> Akamai Object Storage
Akamai/Linode is now -> Akamai Compute