### PR TITLE
Add a notice about URL encoding _APP_SMS_PROVIDER

### DIFF
--- a/app/views/docs/sms-delivery.phtml
+++ b/app/views/docs/sms-delivery.phtml
@@ -93,6 +93,10 @@
 <h2><a href="/docs/sms-delivery#updateEnvFile" id="updateEnvFile">Update Your .env File</a></h2>
 <p>You will need to configure these <a href="/docs/environment-variables#phone">environment variables</a> and restart your Appwrite containers before you can use phone authentication.</p>
 
+<div class="notice">
+    <p>Ensure the values you insert in the <code>_APP_SMS_PROVIDER</code> placeholders are <a href="https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding" target="_blank" rel="noopener">URL encoded</a> if they contain any non-alphanumeric characters.</p>
+</div>
+
 <table class="full">
     <thead>
     <tr>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Inform the user the values must be URL encoded

## Test Plan

Manual:

<img width="900" alt="image" src="https://github.com/appwrite/docs/assets/1477010/709bf1f8-53c7-45b8-b629-1ca769b7b42a">

## Related PRs and Issues

* https://github.com/appwrite/appwrite/pull/5917
* https://github.com/appwrite/appwrite/pull/5916
* https://github.com/utopia-php/dsn/pull/3

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes